### PR TITLE
refactor: remove featured panels from nav dropdowns and consolidate auth buttons

### DIFF
--- a/components/layout/site-header.tsx
+++ b/components/layout/site-header.tsx
@@ -31,14 +31,6 @@ import { cn } from "@/lib/utils";
 import { navigationConfig } from "@/lib/config/navigation";
 import { UserNav } from "./user-nav";
 
-// Featured section background colors (light palette variants)
-const featuredBgColors: Record<string, string> = {
-  "About": "bg-[#f7e5f3]", // Purple Light
-  "Mentorship": "bg-[#f4f4fa]", // Periwinkle Light
-  "Get Involved": "bg-[#eaf2ff]", // Navy Light
-  "Resources": "bg-[#effefb]", // Mint Light
-};
-
 export function SiteHeader() {
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
@@ -148,67 +140,35 @@ export function SiteHeader() {
                         </span>
                       </NavigationMenuTrigger>
                       <NavigationMenuContent className="nav-dropdown-enter nav-dropdown-enter-active">
-                        <div className="flex w-[800px]">
-                          {/* Left side - Navigation links */}
-                          <div className="flex-1 p-6">
-                            <ul className="space-y-1">
-                              {item.children.map((child) => (
-                                <li key={child.title}>
-                                  <NavigationMenuLink asChild>
-                                    <Link
-                                      href={child.href}
-                                      onClick={(e) => handleSmoothScroll(e, child.href)}
-                                      className="flex items-start gap-3 rounded-lg p-3 transition-all duration-150 hover:bg-[#f7e5f3]/80 focus:bg-[#f7e5f3]/80 group"
-                                    >
-                                      {child.icon && (
-                                        <div className="mt-0.5">
-                                          <child.icon className="h-5 w-5 text-muted-foreground group-hover:text-foreground transition-colors duration-150" />
-                                        </div>
-                                      )}
-                                      <div className="flex-1">
-                                        <div className="text-sm font-bold text-foreground group-hover:text-foreground transition-colors duration-150">
-                                          {child.title}
-                                        </div>
-                                        {child.description && (
-                                          <p className="mt-1 text-sm text-muted-foreground group-hover:text-foreground transition-colors duration-150">
-                                            {child.description}
-                                          </p>
-                                        )}
-                                      </div>
-                                    </Link>
-                                  </NavigationMenuLink>
-                                </li>
-                              ))}
-                            </ul>
-                          </div>
-
-                          {/* Right side - Featured section */}
-                          {item.image && (
-                            <Link
-                              href={item.image.href}
-                              className="relative w-80 overflow-hidden group rounded-r-[50px]"
-                            >
-                              {/* Content */}
-                              <div className={cn(
-                                "relative h-full flex items-center justify-center transition-all duration-300",
-                                featuredBgColors[item.title] || "bg-muted",
-                                "group-hover:opacity-90"
-                              )}>
-                                <div className="text-center p-6">
-                                  <div className="text-sm font-medium text-muted-foreground mb-1">
-                                    Featured
+                        <ul className="w-[480px] space-y-1 p-6">
+                          {item.children.map((child) => (
+                            <li key={child.title}>
+                              <NavigationMenuLink asChild>
+                                <Link
+                                  href={child.href}
+                                  onClick={(e) => handleSmoothScroll(e, child.href)}
+                                  className="flex items-start gap-3 rounded-lg p-3 transition-all duration-150 hover:bg-[#f7e5f3]/80 focus:bg-[#f7e5f3]/80 group"
+                                >
+                                  {child.icon && (
+                                    <div className="mt-0.5">
+                                      <child.icon className="h-5 w-5 text-muted-foreground group-hover:text-foreground transition-colors duration-150" />
+                                    </div>
+                                  )}
+                                  <div className="flex-1">
+                                    <div className="text-sm font-bold text-foreground group-hover:text-foreground transition-colors duration-150">
+                                      {child.title}
+                                    </div>
+                                    {child.description && (
+                                      <p className="mt-1 text-sm text-muted-foreground group-hover:text-foreground transition-colors duration-150">
+                                        {child.description}
+                                      </p>
+                                    )}
                                   </div>
-                                  <div className="text-lg font-bold text-foreground">
-                                    {item.image.alt}
-                                  </div>
-                                  <div className="mt-2 text-sm text-muted-foreground group-hover:text-foreground transition-opacity duration-300">
-                                    Explore →
-                                  </div>
-                                </div>
-                              </div>
-                            </Link>
-                          )}
-                        </div>
+                                </Link>
+                              </NavigationMenuLink>
+                            </li>
+                          ))}
+                        </ul>
                       </NavigationMenuContent>
                     </>
                   ) : (
@@ -350,16 +310,6 @@ export function SiteHeader() {
                               {child.title}
                             </Link>
                           ))}
-                          {/* Featured image link */}
-                          {item.image && (
-                            <Link
-                              href={item.image.href}
-                              className="flex items-center gap-2 py-2 text-sm text-[#1f1e44]/70 hover:text-brand transition-all duration-150 hover:bg-[#f7e5f3] rounded-lg px-2 -mx-2"
-                              onClick={() => setIsOpen(false)}
-                            >
-                              {item.image.alt}
-                            </Link>
-                          )}
                         </div>
                       </CollapsibleContent>
                     </Collapsible>

--- a/components/layout/user-nav.tsx
+++ b/components/layout/user-nav.tsx
@@ -127,19 +127,14 @@ export function UserNav({ variant = 'desktop' }: UserNavProps) {
     );
   }
 
-  // Not logged in - show Sign In / Sign Up buttons
+  // Not logged in - show Sign In button (sign-in page has tabs to switch to sign-up)
   if (!user) {
     if (variant === 'mobile') {
       return (
         <div className="flex flex-col gap-2 pt-4 border-t border-[#f7e5f3]">
           <Link href="/sign-in" className="w-full">
-            <Button variant="outline" size="lg" className="w-full">
+            <Button variant="brand" size="lg" className="w-full">
               Sign In
-            </Button>
-          </Link>
-          <Link href="/sign-up" className="w-full">
-            <Button size="lg" className="w-full bg-brand hover:bg-brand/90 text-white">
-              Sign Up
             </Button>
           </Link>
         </div>
@@ -147,18 +142,11 @@ export function UserNav({ variant = 'desktop' }: UserNavProps) {
     }
 
     return (
-      <div className="flex items-center gap-2">
-        <Link href="/sign-in">
-          <Button variant="outline" size="sm">
-            Sign In
-          </Button>
-        </Link>
-        <Link href="/sign-up">
-          <Button size="sm" className="bg-brand hover:bg-brand/90 text-white">
-            Sign Up
-          </Button>
-        </Link>
-      </div>
+      <Link href="/sign-in">
+        <Button variant="brand" size="sm">
+          Sign In
+        </Button>
+      </Link>
     );
   }
 

--- a/lib/config/navigation.ts
+++ b/lib/config/navigation.ts
@@ -24,11 +24,6 @@ export interface NavigationItem {
   description?: string;
   icon?: LucideIcon;
   children?: NavigationItem[];
-  image?: {
-    src: string;
-    alt: string;
-    href: string;
-  };
 }
 
 export interface NavigationButton {
@@ -46,11 +41,6 @@ export const navigationConfig: {
       title: "About",
       href: "/about",
       icon: Users,
-      image: {
-        src: "/img/mesh-954.png",
-        alt: "About She Sharp",
-        href: "/about",
-      },
       children: [
         {
           title: "Our History",
@@ -75,11 +65,6 @@ export const navigationConfig: {
       title: "Mentorship",
       href: "/mentorship",
       icon: GraduationCap,
-      image: {
-        src: "/img/mesh-954.png",
-        alt: "Meet Our Mentors",
-        href: "/mentorship#mentors-list",
-      },
       children: [
         {
           title: "About the Programme",
@@ -105,11 +90,6 @@ export const navigationConfig: {
       title: "Get Involved",
       href: "/join-our-team",
       icon: HandHeart,
-      image: {
-        src: "/img/mesh-152.png",
-        alt: "Donate",
-        href: "/donate",
-      },
       children: [
         {
           title: "Join Our Team",
@@ -130,11 +110,6 @@ export const navigationConfig: {
       title: "Resources",
       href: "/resources",
       icon: Library,
-      image: {
-        src: "/img/mesh-152.png",
-        alt: "Resource Library",
-        href: "/resources",
-      },
       children: [
         {
           title: "Photo Gallery",


### PR DESCRIPTION
## Summary
- Remove the 320px featured content section from desktop and mobile navigation dropdowns, reducing dropdown width from 800px to 480px
- Consolidate separate Sign In / Sign Up buttons into a single Sign In button (sign-in page already has a tab switcher for sign-up)
- Remove `image` property from navigation config interface and all nav items

## Test plan
- [ ] Desktop dropdown menus show only navigation links (no featured panel)
- [ ] Dropdown width is narrower and properly sized
- [ ] Mobile menu no longer shows featured links
- [ ] Only one "Sign In" button appears in both desktop and mobile views
- [ ] Clicking "Sign In" goes to `/sign-in` where users can switch to sign-up via tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)