### PR TITLE
fix: restore Donate and Meet Our Mentors links in nav dropdowns

### DIFF
--- a/lib/config/navigation.ts
+++ b/lib/config/navigation.ts
@@ -16,6 +16,7 @@ import {
   Mail,
   ChartGantt,
   UsersRound,
+  Heart,
 } from "lucide-react";
 
 export interface NavigationItem {
@@ -84,6 +85,12 @@ export const navigationConfig: {
           description: "Apply to share your expertise and guide others",
           icon: Award,
         },
+        {
+          title: "Meet Our Mentors",
+          href: "/mentorship#mentors-list",
+          description: "Browse profiles of our experienced mentors",
+          icon: UsersRound,
+        },
       ],
     },
     {
@@ -103,6 +110,12 @@ export const navigationConfig: {
           href: "/sponsors/corporate-sponsorship",
           description: "Partner with us to support women in STEM",
           icon: Building2,
+        },
+        {
+          title: "Donate",
+          href: "/donate",
+          description: "Support our mission to empower women in STEM",
+          icon: Heart,
         },
       ],
     },


### PR DESCRIPTION
## Summary
- Add "Meet Our Mentors" (`/mentorship#mentors-list`) as a regular child item under Mentorship dropdown
- Add "Donate" (`/donate`) as a regular child item under Get Involved dropdown
- These links were previously only accessible via the featured panels that were removed in #24

## Test plan
- [ ] Mentorship dropdown now shows "Meet Our Mentors" linking to `/mentorship#mentors-list`
- [ ] Get Involved dropdown now shows "Donate" linking to `/donate`
- [ ] All navigation links remain functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)