### PR TITLE
fix: add About and Resource Library links to nav dropdowns

### DIFF
--- a/lib/config/navigation.ts
+++ b/lib/config/navigation.ts
@@ -44,6 +44,12 @@ export const navigationConfig: {
       icon: Users,
       children: [
         {
+          title: "About She Sharp",
+          href: "/about",
+          description: "Our mission, vision, and the story behind She Sharp",
+          icon: Users,
+        },
+        {
           title: "Our History",
           href: "/about#timeline",
           description: "A deep dive into our journey since 2014",
@@ -124,6 +130,12 @@ export const navigationConfig: {
       href: "/resources",
       icon: Library,
       children: [
+        {
+          title: "Resource Library",
+          href: "/resources",
+          description: "Explore all resources including newsletters and media",
+          icon: Library,
+        },
         {
           title: "Photo Gallery",
           href: "/resources/photo-gallery",


### PR DESCRIPTION
## Summary
- Add "About She Sharp" (`/about`) as first child under About dropdown
- Add "Resource Library" (`/resources`) as first child under Resources dropdown
- Completes migration of all 4 featured panel links into regular dropdown children

## Context
Previous fix (#25) added Donate and Meet Our Mentors but missed About and Resources. Although these are set as parent `href`, clicking the parent only opens the dropdown — it does not navigate. Explicit child links are needed for all 4 former featured destinations.

## Test plan
- [ ] About dropdown shows "About She Sharp" linking to `/about`
- [ ] Resources dropdown shows "Resource Library" linking to `/resources`
- [ ] All 4 former featured links are now accessible as regular dropdown items

🤖 Generated with [Claude Code](https://claude.com/claude-code)