### PR TITLE
style: photo gallery responsive design & border-radius optimization

### DIFF
--- a/components/resources/albums.tsx
+++ b/components/resources/albums.tsx
@@ -99,7 +99,7 @@ export function GalleryAlbumsGrid() {
     <Section spacing="section" className="py-24 lg:py-36">
       <Container size="full">
         {/* Header */}
-        <div className="mb-10 md:mb-14">
+        <div className="mb-8 sm:mb-10 md:mb-14">
           <h1 className="text-display-sm">Photo Gallery</h1>
           <p className="mt-3 text-base md:text-lg text-muted-foreground max-w-2xl">
             Explore highlights from She Sharp events, workshops, and community
@@ -109,7 +109,7 @@ export function GalleryAlbumsGrid() {
 
         {/* Search and Filter Controls */}
         <div className="space-y-4 mb-8">
-          <div className="flex flex-col md:flex-row gap-6 md:gap-16 md:items-center">
+          <div className="flex flex-col md:flex-row items-start gap-4 sm:gap-6 md:gap-8 md:items-center">
             {/* Search Bar */}
             <div className="relative flex-1">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
@@ -202,13 +202,13 @@ export function GalleryAlbumsGrid() {
 
         {/* Albums Grid */}
         {displayedAlbums.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-5 md:gap-6 lg:gap-8">
             {displayedAlbums.map((album) => (
               <AlbumCard key={album.googlePhotosUrl} album={album} />
             ))}
           </div>
         ) : (
-          <div className="text-center py-16">
+          <div className="card-sm text-center py-16 bg-muted/30">
             <p className="text-lg text-muted-foreground">
               No albums found. Try adjusting your search or filters.
             </p>
@@ -222,7 +222,7 @@ export function GalleryAlbumsGrid() {
               variant="outline"
               size="lg"
               onClick={handleLoadMore}
-              className="h-12 px-8 text-base"
+              className="h-12 px-8 text-base card-sm"
             >
               Load More
             </Button>

--- a/components/resources/bento-cards/album-card.tsx
+++ b/components/resources/bento-cards/album-card.tsx
@@ -22,7 +22,7 @@ export function AlbumCard({ album, compact = false }: AlbumCardProps) {
       className="block h-full group"
       aria-label={`View ${album.title} album in Google Photos`}
     >
-      <Card className="relative h-full w-full overflow-hidden border-0 shadow-lg transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-1 rounded-[30px] aspect-3/4">
+      <Card className="relative h-full w-full border-0 shadow-lg transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-1 card-sm aspect-3/4">
         {/* Cover Image */}
         <img
           src={album.coverImage}
@@ -34,7 +34,7 @@ export function AlbumCard({ album, compact = false }: AlbumCardProps) {
         <div className="absolute inset-0 bg-linear-to-t from-black/70 via-black/25 to-transparent" />
 
         {/* View Photos Badge */}
-        <div className="absolute top-6 right-6 z-10 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+        <div className="absolute top-4 right-4 sm:top-5 sm:right-5 md:top-6 md:right-6 z-10 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
           <div className="glass-pill bg-white px-3 py-1.5 flex items-center gap-1.5">
             <Images className="h-3.5 w-3.5 text-purple-dark" />
             <span className="text-xs font-medium text-purple-dark">View Photos</span>
@@ -42,13 +42,13 @@ export function AlbumCard({ album, compact = false }: AlbumCardProps) {
         </div>
 
         {/* Content */}
-        <div className="absolute bottom-0 left-0 right-0 p-6 z-10">
+        <div className="absolute bottom-0 left-0 right-0 p-4 sm:p-5 md:p-6 z-10">
           {!compact && (
             <p className="text-xs font-medium text-white/80 uppercase tracking-wider mb-1">
               {album.date}
             </p>
           )}
-          <h3 className={`font-bold text-white line-clamp-2 ${compact ? "text-base" : "text-lg"}`}>
+          <h3 className={`font-bold text-white line-clamp-2 ${compact ? "text-base" : "text-base sm:text-lg"}`}>
             {album.title}
           </h3>
         </div>

--- a/components/resources/bento-cards/featured-album-card.tsx
+++ b/components/resources/bento-cards/featured-album-card.tsx
@@ -21,7 +21,7 @@ export function FeaturedAlbumCard({ album }: FeaturedAlbumCardProps) {
       className="block h-full group"
       aria-label={`View ${album.title} album in Google Photos`}
     >
-      <Card className="relative h-full w-full overflow-hidden border-0 shadow-lg transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-1 rounded-[50px]">
+      <Card className="relative h-full w-full border-0 shadow-lg transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-1 card-lg">
         {/* Cover Image */}
         <img
           src={album.coverImage}
@@ -33,21 +33,21 @@ export function FeaturedAlbumCard({ album }: FeaturedAlbumCardProps) {
         <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
 
         {/* Top Badge */}
-        <div className="absolute top-8 left-8 z-10">
+        <div className="absolute top-4 left-4 sm:top-6 sm:left-6 md:top-8 md:left-8 z-10">
           <div className="glass-pill bg-white/90 px-4 py-1.5">
             <p className="text-sm font-semibold text-purple-dark">Featured Album</p>
           </div>
         </div>
 
         {/* External Link Icon */}
-        <div className="absolute top-8 right-8 z-10 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+        <div className="absolute top-4 right-4 sm:top-6 sm:right-6 md:top-8 md:right-8 z-10 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
           <div className="glass-pill bg-white/90 p-2">
             <ExternalLink className="h-4 w-4 text-purple-dark" />
           </div>
         </div>
 
         {/* Content Overlay */}
-        <div className="absolute bottom-0 left-0 right-0 p-8 z-10">
+        <div className="absolute bottom-0 left-0 right-0 p-4 sm:p-6 md:p-8 z-10">
           <p className="text-xs font-medium text-white/80 uppercase tracking-wider mb-2">
             {album.date}
           </p>

--- a/components/resources/bento-cards/photo-gallery-preview-card.tsx
+++ b/components/resources/bento-cards/photo-gallery-preview-card.tsx
@@ -14,7 +14,7 @@ export function PhotoGalleryPreviewCard() {
 
   return (
     <Link href="/resources/photo-gallery" className="block h-full group">
-      <Card className="relative h-full w-full min-h-[400px] md:min-h-[500px] overflow-hidden border-0 shadow-lg transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-1 rounded-[50px] bg-black">
+      <Card className="relative h-full w-full min-h-[300px] sm:min-h-[400px] md:min-h-[500px] border-0 shadow-lg transition-all duration-300 group-hover:shadow-xl group-hover:-translate-y-1 card-lg bg-black">
         {/* Background image */}
         {featured && (
           <img
@@ -28,7 +28,7 @@ export function PhotoGalleryPreviewCard() {
         <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent" />
 
         {/* Badge */}
-        <div className="absolute top-6 left-6 z-10">
+        <div className="absolute top-4 left-4 sm:top-5 sm:left-5 md:top-6 md:left-6 z-10">
           <span className="inline-flex items-center gap-1.5 rounded-full bg-white/90 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-gray-900">
             <Images className="h-3.5 w-3.5" />
             Photo Gallery
@@ -36,7 +36,7 @@ export function PhotoGalleryPreviewCard() {
         </div>
 
         {/* Content */}
-        <div className="absolute inset-x-6 bottom-6 z-10 flex items-end justify-between gap-4">
+        <div className="absolute inset-x-4 bottom-4 sm:inset-x-5 sm:bottom-5 md:inset-x-6 md:bottom-6 z-10 flex items-end justify-between gap-4">
           <div>
             <h3 className="text-2xl md:text-3xl font-bold text-white leading-snug line-clamp-2">
               Event Photos & Highlights


### PR DESCRIPTION
## Summary
- Replace hardcoded `rounded-[30px]`/`rounded-[50px]` with design system classes (`card-sm`/`card-lg`) across all gallery card components
- Add `sm` breakpoints for grid layout, padding, and badge positioning for smoother mobile-to-desktop scaling
- Refine search/filter control spacing and add polished empty state styling

## Changed Files
- `components/resources/albums.tsx` — Grid layout, header spacing, filter gap, empty state, load more button
- `components/resources/bento-cards/album-card.tsx` — Border radius, responsive padding/positioning/title
- `components/resources/bento-cards/featured-album-card.tsx` — Border radius, responsive padding/positioning
- `components/resources/bento-cards/photo-gallery-preview-card.tsx` — Border radius, responsive min-height/positioning

## Test plan
- [ ] Verify gallery page renders correctly at 320px, 375px, 640px, 768px, 1024px, 1280px+
- [ ] Check hover effects on all card types at each breakpoint
- [ ] Confirm 2-column grid starts at `sm` (640px) and 3-column at `lg` (1024px)
- [ ] Verify empty state and load more button styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)