### PR TITLE
style: optimize podcasts page responsive design and border-radius tokens

### DIFF
--- a/app/(site)/resources/podcasts/page.tsx
+++ b/app/(site)/resources/podcasts/page.tsx
@@ -18,9 +18,9 @@ export default function PodcastsPage() {
   const showEmbedUrl = getSpotifyShowEmbedUrl();
 
   return (
-    <Section spacing="section" className="py-24 lg:py-36">
+    <Section spacing="section" className="py-16 md:py-24 lg:py-32">
       <Container size="full">
-        <div className="mb-10 md:mb-14 max-w-3xl">
+        <div className="mb-8 sm:mb-10 md:mb-14 lg:mb-16 max-w-3xl">
           <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold tracking-tight">
             She Sharp Talks
           </h1>
@@ -32,8 +32,8 @@ export default function PodcastsPage() {
         </div>
 
         {/* Show embed */}
-        <div className="mb-12">
-          <div className="overflow-hidden rounded-3xl shadow-lg">
+        <div className="mb-8 sm:mb-10 md:mb-12">
+          <div className="card-responsive-lg shadow-lg">
             <iframe
               src={showEmbedUrl}
               width="100%"
@@ -47,15 +47,15 @@ export default function PodcastsPage() {
         </div>
 
         {/* Featured episodes */}
-        <div className="space-y-6">
-          <h2 className="text-xl md:text-2xl font-semibold">
+        <div className="space-y-4 sm:space-y-5 md:space-y-6 lg:space-y-8">
+          <h2 className="text-xl sm:text-2xl lg:text-3xl font-semibold">
             Featured episodes
           </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 sm:gap-5 md:gap-6 lg:gap-8">
             {FEATURED_EPISODES.map((episode) => (
               <div
                 key={episode.id}
-                className="overflow-hidden rounded-3xl shadow-md bg-background"
+                className="card-responsive-sm shadow-md bg-background"
               >
                 <iframe
                   src={getSpotifyEpisodeEmbedUrl(episode.id)}

--- a/styles/components/cards.css
+++ b/styles/components/cards.css
@@ -14,6 +14,36 @@
     overflow: hidden;
   }
 
+  .card-responsive-sm {
+    border-radius: 20px;
+    overflow: hidden;
+  }
+  @media (min-width: 640px) {
+    .card-responsive-sm { border-radius: var(--radius-card-sm); /* 30px */ }
+  }
+
+  .card-responsive-md {
+    border-radius: 24px;
+    overflow: hidden;
+  }
+  @media (min-width: 640px) {
+    .card-responsive-md { border-radius: var(--radius-card-sm); /* 30px */ }
+  }
+  @media (min-width: 768px) {
+    .card-responsive-md { border-radius: var(--radius-card-md); /* 40px */ }
+  }
+
+  .card-responsive-lg {
+    border-radius: var(--radius-card-sm); /* 30px */
+    overflow: hidden;
+  }
+  @media (min-width: 768px) {
+    .card-responsive-lg { border-radius: var(--radius-card-md); /* 40px */ }
+  }
+  @media (min-width: 1024px) {
+    .card-responsive-lg { border-radius: var(--radius-card-lg); /* 50px */ }
+  }
+
   .card-glass {
     @apply border border-border/30 bg-white/50 backdrop-blur-md backdrop-saturate-150
            shadow-lg shadow-black/5 transition-all duration-300;


### PR DESCRIPTION
## Summary
- Add responsive card utility classes (`card-responsive-sm/md/lg`) in `cards.css` that scale border-radius across breakpoints using design system tokens (30/40/50px)
- Refine podcasts page spacing, grid layout (3-col at xl), and typography for all screen sizes
- Replace hardcoded `rounded-3xl` with design system token-based responsive classes

## Test plan
- [ ] Visit `/resources/podcasts` and resize browser across breakpoints (375px, 640px, 768px, 1024px, 1280px)
- [ ] Verify border-radius transitions smoothly at each breakpoint
- [ ] Verify grid switches to 2-col at sm and 3-col at xl
- [ ] Verify spacing scales proportionally across screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)