### PR TITLE
style: optimize join-our-team page layout and design tokens

### DIFF
--- a/app/(site)/join-our-team/page.tsx
+++ b/app/(site)/join-our-team/page.tsx
@@ -1,9 +1,8 @@
 import { Metadata } from "next";
 import { JoinTeamHeroSection } from "@/components/join-team/join-team-hero-section";
-import { VolunteerPathsSection } from "@/components/join-team/volunteer-paths-section";
+import { PricingComparison } from "@/components/ui/pricing-section-with-comparison";
 import { JoinTeamTestimonialsSection } from "@/components/join-team/testimonials-section";
 import {
-  volunteerImages,
   volunteerPaths,
   joinTeamStats,
   joinTeamContent,
@@ -23,17 +22,7 @@ export default function JoinOurTeamPage() {
         description={joinTeamContent.description}
         stats={joinTeamStats}
       />
-      <VolunteerPathsSection
-        title={joinTeamContent.title}
-        description={joinTeamContent.description}
-        stats={joinTeamStats.map(stat => stat.text)}
-        volunteerPaths={volunteerPaths}
-        tabs={volunteerImages}
-        primaryCta={{
-          label: "Apply Now",
-          href: "mailto:people@shesharp.org.nz",
-        }}
-      />
+      <PricingComparison volunteerPaths={volunteerPaths} />
       <JoinTeamTestimonialsSection />
     </section>
   );

--- a/components/join-team/join-team-hero-section.tsx
+++ b/components/join-team/join-team-hero-section.tsx
@@ -35,9 +35,9 @@ export function JoinTeamHeroSection({
   const rightImages = GALLERY_IMAGES.slice(3);
 
   return (
-    <div className="bg-periwinkle-soft py-24 lg:py-36">
-      <div className="container mx-auto max-w-8xl px-6">
-        <div className="flex flex-col gap-10 lg:gap-16">
+    <div className="bg-periwinkle-soft py-16 md:py-24 lg:py-32">
+      <div className="mx-auto max-w-8xl px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col gap-6 sm:gap-8 md:gap-10 lg:gap-16">
           {/* Text Content */}
           <div className="flex flex-col items-center">
             <h1 className="text-display-sm text-white mb-4 text-center">
@@ -52,7 +52,7 @@ export function JoinTeamHeroSection({
 
             {/* Stats with icons */}
             {stats.length > 0 && (
-              <div className="flex flex-wrap gap-10 mb-8 justify-center">
+              <div className="flex flex-wrap gap-4 sm:gap-6 md:gap-10 mb-8 justify-center">
                 {stats.map((stat, i) => {
                   const Icon = iconMap[stat.iconName];
                   return (
@@ -72,13 +72,13 @@ export function JoinTeamHeroSection({
 
           {/* Image Gallery Section */}
           <div className="w-full">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-5 md:gap-6">
               {/* Left Column: Two images stacked */}
-              <div className="flex flex-col gap-4 md:gap-6">
+              <div className="flex flex-col gap-4 sm:gap-5 md:gap-6">
                 {leftImages.map((image) => (
                   <div
                     key={image.src}
-                    className="relative w-full aspect-4/3 overflow-hidden rounded-2xl"
+                    className="relative w-full aspect-4/3 card-sm"
                   >
                     <Image
                       src={image.src}
@@ -92,24 +92,24 @@ export function JoinTeamHeroSection({
               </div>
 
               {/* Center Column: Large image */}
-              <div className="relative w-full overflow-hidden rounded-2xl flex items-center justify-center">
+              <div className="relative w-full card-sm flex items-center justify-center">
                 <Image
                   src={centerImage.src}
                   alt={centerImage.alt}
                   width={0}
                   height={0}
-                  className="w-full h-auto rounded-2xl"
+                  className="w-full h-auto"
                   sizes="(max-width: 768px) 100vw, 33vw"
                   priority
                 />
               </div>
 
               {/* Right Column: Two images stacked */}
-              <div className="flex flex-col gap-4 md:gap-6">
+              <div className="flex flex-col gap-4 sm:gap-5 md:gap-6">
                 {rightImages.map((image) => (
                   <div
                     key={image.src}
-                    className="relative w-full aspect-4/3 overflow-hidden rounded-2xl"
+                    className="relative w-full aspect-4/3 card-sm"
                   >
                     <Image
                       src={image.src}

--- a/components/join-team/testimonials-section.tsx
+++ b/components/join-team/testimonials-section.tsx
@@ -60,15 +60,15 @@ export function JoinTeamTestimonialsSection() {
     );
 
     return (
-        <section className="w-full bg-muted/30 py-16 xl:py-24 2xl:py-32">
+        <section className="w-full bg-muted/30 py-16 md:py-20 lg:py-24 xl:py-28">
             <Container size="full">
-                <div className="mb-12">
+                <div>
                     {/* Header with title and navigation */}
-                    <div className="flex items-center justify-between mb-8">
-                        <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-foreground">
+                    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
+                        <h2 className="text-display-sm text-foreground">
                             What People Say About She Sharp
                         </h2>
-                        <div className="flex items-center gap-2">
+                        <div className="flex items-center gap-2 shrink-0">
                             <Button
                                 variant="ghost"
                                 size="icon"
@@ -97,11 +97,11 @@ export function JoinTeamTestimonialsSection() {
                     </div>
 
                     {/* Testimonials Grid */}
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8 py-4 md:py-6">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-5 md:gap-6 mb-8">
                         {visibleTestimonials.map((testimonial, index) => (
                             <Card
                                 key={`${currentIndex + index}-${testimonial.name}`}
-                                className="p-6 bg-white shadow-sm hover:shadow-md transition-shadow flex flex-col"
+                                className="card-sm p-4 sm:p-5 md:p-6 bg-white shadow-sm hover:shadow-md transition-all duration-300 flex flex-col"
                             >
                                 <p className="text-base text-foreground mb-6 leading-relaxed flex-1">
                                     {testimonial.content}

--- a/components/ui/pricing-section-with-comparison.tsx
+++ b/components/ui/pricing-section-with-comparison.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Check, Minus, Clock, ArrowRight } from "lucide-react";
+import Link from "next/link";
+import type { VolunteerPath } from "@/components/join-team/types";
+
+interface FeatureRow {
+  name: string;
+  /** Which path IDs include this feature */
+  includedIn: string[];
+}
+
+interface FeatureCategory {
+  title: string;
+  features: FeatureRow[];
+}
+
+function buildComparisonData(paths: VolunteerPath[]): FeatureCategory[] {
+  const allHighlights = new Set<string>();
+  const allResponsibilities = new Set<string>();
+  const allBenefits = new Set<string>();
+
+  for (const path of paths) {
+    path.highlights.forEach((h) => allHighlights.add(h));
+    path.responsibilities.forEach((r) => allResponsibilities.add(r));
+    path.benefits.forEach((b) => allBenefits.add(b));
+  }
+
+  function buildRows(
+    allItems: Set<string>,
+    key: "highlights" | "responsibilities" | "benefits"
+  ): FeatureRow[] {
+    return Array.from(allItems).map((item) => ({
+      name: item,
+      includedIn: paths.filter((p) => p[key].includes(item)).map((p) => p.id),
+    }));
+  }
+
+  return [
+    { title: "Highlights", features: buildRows(allHighlights, "highlights") },
+    {
+      title: "Responsibilities",
+      features: buildRows(allResponsibilities, "responsibilities"),
+    },
+    { title: "Benefits", features: buildRows(allBenefits, "benefits") },
+  ];
+}
+
+function getPathHref(id: string): string {
+  if (id === "volunteer") return "/join-our-team/apply?type=volunteer";
+  if (id === "ambassador") return "/join-our-team/apply?type=ambassador";
+  if (id === "ex-ambassador") return "/join-our-team/apply/ex-ambassador";
+  return "/join-our-team";
+}
+
+function getButtonLabel(id: string): string {
+  return id === "ex-ambassador" ? "Share Feedback" : "Apply Now";
+}
+
+export function PricingComparison({
+  volunteerPaths,
+}: {
+  volunteerPaths: VolunteerPath[];
+}) {
+  // Display in reverse order (same as old component)
+  const paths = [...volunteerPaths].reverse();
+  const categories = buildComparisonData(paths);
+
+  return (
+    <section className="w-full py-16 md:py-24 bg-white text-foreground">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        {/* Header */}
+        <div className="text-center mb-12 md:mb-16">
+          <Badge
+            variant="outline"
+            className="mb-4 px-4 py-1.5 text-sm font-medium border-brand/30 text-brand"
+          >
+            Choose Your Path
+          </Badge>
+          <h2 className="text-display-sm text-foreground mb-4">
+            Compare Volunteer Paths
+          </h2>
+          <p className="text-base md:text-lg text-muted-foreground max-w-2xl mx-auto">
+            Whether you have a few hours or want to make a bigger commitment,
+            there&apos;s a place for you on our team.
+          </p>
+        </div>
+
+        {/* Mobile cards (visible below lg) */}
+        <div className="lg:hidden space-y-6">
+          {paths.map((path, index) => (
+            <div
+              key={path.id}
+              className={cn(
+                "rounded-2xl border p-6",
+                index === 0 ? "border-brand/30" : "border-border"
+              )}
+            >
+              <h3 className="text-xl font-bold text-foreground mb-1">
+                {path.title}
+              </h3>
+              <p className="text-sm text-muted-foreground mb-3">
+                {path.description}
+              </p>
+              <div className="flex items-center gap-1.5 text-sm text-muted-foreground mb-5">
+                <Clock className="w-4 h-4" />
+                {path.commitment}
+              </div>
+
+              {categories.map((category) => (
+                <div key={category.title} className="mb-4">
+                  <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+                    {category.title}
+                  </h4>
+                  <ul className="space-y-1.5">
+                    {category.features.map((feature) => {
+                      const included = feature.includedIn.includes(path.id);
+                      return (
+                        <li
+                          key={feature.name}
+                          className="flex items-start gap-2 text-sm"
+                        >
+                          {included ? (
+                            <Check
+                              className={cn(
+                                "w-4 h-4 mt-0.5 shrink-0",
+                                index === 0
+                                  ? "text-brand"
+                                  : "text-periwinkle-dark"
+                              )}
+                            />
+                          ) : (
+                            <Minus className="w-4 h-4 mt-0.5 shrink-0 text-muted-foreground/30" />
+                          )}
+                          <span
+                            className={
+                              included
+                                ? "text-foreground"
+                                : "text-muted-foreground/40"
+                            }
+                          >
+                            {feature.name}
+                          </span>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ))}
+
+              <Button
+                asChild
+                size="lg"
+                variant={index === 0 ? "brand" : "outline"}
+                className="w-full mt-2"
+              >
+                <Link href={getPathHref(path.id)}>
+                  {getButtonLabel(path.id)}
+                  <ArrowRight className="w-4 h-4 ml-2" />
+                </Link>
+              </Button>
+            </div>
+          ))}
+        </div>
+
+        {/* Desktop comparison table (visible at lg+) */}
+        <div className="hidden lg:block">
+          <div className="rounded-2xl border border-border overflow-hidden">
+            {/* Column headers */}
+            <div className="grid grid-cols-4 divide-x divide-border">
+              {/* Empty top-left cell */}
+              <div className="p-6 bg-muted/30" />
+
+              {/* Path headers */}
+              {paths.map((path, index) => (
+                <div
+                  key={path.id}
+                  className={cn(
+                    "p-6 text-center",
+                    index === 0 ? "bg-brand/5" : "bg-muted/30"
+                  )}
+                >
+                  <h3 className="text-lg font-bold text-foreground mb-1">
+                    {path.title}
+                  </h3>
+                  <p className="text-sm text-muted-foreground mb-3 line-clamp-2">
+                    {path.description}
+                  </p>
+                  <div className="flex items-center justify-center gap-1.5 text-sm text-muted-foreground mb-4">
+                    <Clock className="w-4 h-4" />
+                    {path.commitment}
+                  </div>
+                  <Button
+                    asChild
+                    size="default"
+                    variant={index === 0 ? "brand" : "outline"}
+                    className="w-full"
+                  >
+                    <Link href={getPathHref(path.id)}>
+                      {getButtonLabel(path.id)}
+                      <ArrowRight className="w-4 h-4 ml-2" />
+                    </Link>
+                  </Button>
+                </div>
+              ))}
+            </div>
+
+            {/* Feature categories */}
+            {categories.map((category) => (
+              <div key={category.title}>
+                {/* Category header row */}
+                <div className="grid grid-cols-4 divide-x divide-border bg-muted/50">
+                  <div className="p-4">
+                    <span className="text-sm font-semibold uppercase tracking-wider text-foreground">
+                      {category.title}
+                    </span>
+                  </div>
+                  <div className="col-span-3" />
+                </div>
+
+                {/* Feature rows */}
+                {category.features.map((feature) => (
+                  <div
+                    key={feature.name}
+                    className="grid grid-cols-4 divide-x divide-border border-t border-border hover:bg-muted/20 transition-colors"
+                  >
+                    <div className="p-4 flex items-center">
+                      <span className="text-sm text-foreground">
+                        {feature.name}
+                      </span>
+                    </div>
+                    {paths.map((path, index) => {
+                      const included = feature.includedIn.includes(path.id);
+                      return (
+                        <div
+                          key={path.id}
+                          className={cn(
+                            "p-4 flex items-center justify-center",
+                            index === 0 ? "bg-brand/[0.02]" : ""
+                          )}
+                        >
+                          {included ? (
+                            <Check
+                              className={cn(
+                                "w-5 h-5",
+                                index === 0
+                                  ? "text-brand"
+                                  : "text-periwinkle-dark"
+                              )}
+                            />
+                          ) : (
+                            <Minus className="w-5 h-5 text-muted-foreground/30" />
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/ui/pricing-section-with-comparison.tsx
+++ b/components/ui/pricing-section-with-comparison.tsx
@@ -70,10 +70,10 @@ export function PricingComparison({
   const categories = buildComparisonData(paths);
 
   return (
-    <section className="w-full py-16 md:py-24 bg-white text-foreground">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <section className="w-full py-16 md:py-20 lg:py-24 bg-white text-foreground">
+      <div className="mx-auto max-w-8xl px-4 sm:px-6 lg:px-8">
         {/* Header */}
-        <div className="text-center mb-12 md:mb-16">
+        <div className="text-center mb-8 sm:mb-10 md:mb-12 lg:mb-16">
           <Badge
             variant="outline"
             className="mb-4 px-4 py-1.5 text-sm font-medium border-brand/30 text-brand"
@@ -90,12 +90,12 @@ export function PricingComparison({
         </div>
 
         {/* Mobile cards (visible below lg) */}
-        <div className="lg:hidden space-y-6">
+        <div className="lg:hidden grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
           {paths.map((path, index) => (
             <div
               key={path.id}
               className={cn(
-                "rounded-2xl border p-6",
+                "card-sm border p-4 sm:p-5 md:p-6 transition-all duration-300 hover:shadow-md",
                 index === 0 ? "border-brand/30" : "border-border"
               )}
             >
@@ -168,7 +168,7 @@ export function PricingComparison({
 
         {/* Desktop comparison table (visible at lg+) */}
         <div className="hidden lg:block">
-          <div className="rounded-2xl border border-border overflow-hidden">
+          <div className="card-sm border border-border">
             {/* Column headers */}
             <div className="grid grid-cols-4 divide-x divide-border">
               {/* Empty top-left cell */}


### PR DESCRIPTION
## Summary
- Replace volunteer path cards with a pricing comparison table for clearer side-by-side volunteer path comparison
- Optimize responsive design across all 3 join-our-team section components by adding intermediate `sm:`/`md:` breakpoints to prevent jarring layout jumps
- Replace hardcoded `rounded-2xl` (16px) with design system `card-sm` (30px) tokens for consistent border-radius across the site

## Test plan
- [ ] Verify `/join-our-team` page renders correctly at 375px, 640px, 768px, 1024px, 1280px, 1536px
- [ ] Confirm border-radius visually matches other pages using `card-sm`
- [ ] Confirm testimonial carousel navigation still works
- [ ] Confirm all Apply/Feedback buttons link correctly
- [ ] Verify no overflow or text clipping at any viewport width

🤖 Generated with [Claude Code](https://claude.com/claude-code)