### PR TITLE
fix(slack-bot): bundle events-custom.json via import + surface runtime errors

### DIFF
--- a/app/api/slack/events/route.ts
+++ b/app/api/slack/events/route.ts
@@ -10,8 +10,6 @@
  */
 
 import { after } from "next/server";
-import { readFileSync } from "fs";
-import { join } from "path";
 
 import {
   buildAckMessage,
@@ -31,8 +29,11 @@ import { respondToSlack } from "@/lib/slack-bot/slack-client";
 import { SlackBotError, InvalidSignatureError } from "@/lib/slack-bot/errors";
 import { verifySlackSignature } from "@/lib/slack-bot/verify";
 import { nanoid } from "nanoid";
-
-const EVENTS_JSON_PATH = "lib/data/json/events-custom.json";
+// Importing the JSON file directly is the Next.js-safe way: webpack bundles it
+// into the serverless function. Using readFileSync() from lib/ at runtime is
+// unreliable on Vercel because those files are only bundled if webpack traces
+// them via import.
+import eventsCustomData from "@/lib/data/json/events-custom.json";
 
 export async function POST(request: Request): Promise<Response> {
   const rawBody = await request.text();
@@ -88,7 +89,7 @@ async function processCommand(params: {
   try {
     const snapshot = await fetchChannelSnapshot(params.channelId);
 
-    const currentJsonText = readFileSync(join(process.cwd(), EVENTS_JSON_PATH), "utf8");
+    const currentJsonText = JSON.stringify(eventsCustomData, null, 2);
 
     const patch = await extractEventPatch({
       userCommand: params.userCommand,
@@ -133,7 +134,10 @@ async function processCommand(params: {
       }),
     );
   } catch (e) {
-    const message = e instanceof SlackBotError ? e.userMessage : "Unexpected error. Check Vercel logs.";
+    const detail = e instanceof Error ? `${e.name}: ${e.message}` : String(e);
+    const message = e instanceof SlackBotError
+      ? e.userMessage
+      : `Unexpected error — ${detail}`;
     await respondToSlack(params.responseUrl, buildErrorMessage(message));
     console.error("[slack-bot] processCommand failed:", e);
   }

--- a/lib/slack-bot/sponsor-registry.ts
+++ b/lib/slack-bot/sponsor-registry.ts
@@ -9,8 +9,13 @@
 import { readdirSync, existsSync } from "fs";
 import { join, extname, basename } from "path";
 
-const SPONSORS_DIR = "public/img/sponsors";
 const IMAGE_EXTS = new Set([".svg", ".png", ".jpg", ".jpeg", ".webp"]);
+const CANDIDATE_ROOTS = [
+  "public/img/sponsors",
+  // Next.js serverless functions run from `.next/standalone/` on Vercel
+  // where `public/` may be a sibling path; try both variants.
+  ".next/standalone/public/img/sponsors",
+];
 
 let cache: string[] | null = null;
 
@@ -23,17 +28,20 @@ let cache: string[] | null = null;
 export function getSponsorSlugs(): string[] {
   if (cache) return cache;
 
-  const abs = join(process.cwd(), SPONSORS_DIR);
-  if (!existsSync(abs)) {
-    cache = [];
+  for (const root of CANDIDATE_ROOTS) {
+    const abs = join(process.cwd(), root);
+    if (!existsSync(abs)) continue;
+    const slugs = readdirSync(abs)
+      .filter((f) => IMAGE_EXTS.has(extname(f).toLowerCase()))
+      .map((f) => basename(f, extname(f)).toLowerCase());
+    cache = [...new Set(slugs)].sort();
     return cache;
   }
 
-  const slugs = readdirSync(abs)
-    .filter((f) => IMAGE_EXTS.has(extname(f).toLowerCase()))
-    .map((f) => basename(f, extname(f)).toLowerCase());
-
-  cache = [...new Set(slugs)].sort();
+  // If we can't scan the directory at runtime, fall back to empty list —
+  // the AI will still work, it just won't know about existing sponsors and
+  // will propose placeholder paths (admin can correct manually).
+  cache = [];
   return cache;
 }
 


### PR DESCRIPTION
## Summary

Hotfix for the M1 Slack bot (PR #42) after first production invocation returned "Unexpected error" without detail.

## Fixes

### 1. Events JSON bundling
`app/api/slack/events/route.ts` now imports `lib/data/json/events-custom.json` directly instead of `fs.readFileSync()` at request time. Webpack traces imports and bundles the JSON into the Vercel serverless lambda; `readFileSync` of a `lib/` path is unreliable because those files are only in the lambda when imported.

### 2. Error surfacing
`processCommand` catch now appends the actual `error.name: error.message` to the Slack ephemeral instead of the generic placeholder — future failures are self-diagnosing without Vercel logs.

### 3. Sponsor registry resilience
`sponsor-registry.ts` tries multiple path roots and falls back to empty list if `public/img/sponsors/` can't be scanned at runtime. A missing sponsor scan now just means the AI won't know about existing logos (still works), rather than crashing the bot.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Merge, wait Vercel redeploy
- [ ] Retry `/event` in Slack channel — expect either a preview or a specific error message (not "Unexpected error")

## Risk
**Low.** All changes are in the bot code path only. Existing M0/M1 behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)