### PR TITLE
fix(slack-bot): inline sponsor list to keep lambda under 300mb

### DIFF
--- a/lib/slack-bot/sponsor-registry.ts
+++ b/lib/slack-bot/sponsor-registry.ts
@@ -1,53 +1,62 @@
 /**
- * Scans public/img/sponsors/ at runtime and returns the canonical slugs.
+ * Canonical sponsor slugs that exist as SVGs at /img/sponsors/<slug>.svg.
  *
- * Used as context for the AI extractor: when a sponsor matches one of
- * these slugs, the bot reuses the existing logo instead of proposing
- * a new event-scoped copy.
+ * STATIC list (not fs-scanned at runtime) because Next.js's file tracer
+ * would otherwise pull the entire public/ directory into the serverless
+ * lambda bundle, pushing it over Vercel's 300mb size limit.
+ *
+ * When a new canonical sponsor logo is added to public/img/sponsors/,
+ * update this list. The AI uses this to decide whether to reuse an
+ * existing logo or propose an event-specific placeholder.
  */
 
-import { readdirSync, existsSync } from "fs";
-import { join, extname, basename } from "path";
-
-const IMAGE_EXTS = new Set([".svg", ".png", ".jpg", ".jpeg", ".webp"]);
-const CANDIDATE_ROOTS = [
-  "public/img/sponsors",
-  // Next.js serverless functions run from `.next/standalone/` on Vercel
-  // where `public/` may be a sibling path; try both variants.
-  ".next/standalone/public/img/sponsors",
+export const CANONICAL_SPONSOR_SLUGS = [
+  "academyex",
+  "aifnz",
+  "air-new-zealand",
+  "anz",
+  "auckland-council",
+  "aut",
+  "aws",
+  "centrality",
+  "countdown",
+  "deloitte",
+  "ey",
+  "fergus",
+  "fiserv",
+  "flexware",
+  "fonterra",
+  "fph",
+  "geo-ar-games",
+  "google",
+  "grid-akl",
+  "hcltech",
+  "hpe",
+  "ibm",
+  "kiwibank",
+  "lesmills_logo",
+  "metlifecare",
+  "microsoft",
+  "msd",
+  "myob",
+  "nyriad",
+  "orion-health",
+  "pushpay",
+  "secure-code-warrior",
+  "trade-me",
+  "vector",
+  "vend",
+  "wahine-kakano",
+  "westpac",
+  "woolworths",
+  "workday",
+  "xero",
 ];
 
-let cache: string[] | null = null;
-
-/**
- * Returns the list of canonical sponsor slugs.
- *
- * Cached for the lifetime of the serverless function instance (cleared
- * on cold start). Safe to call from hot request paths.
- */
 export function getSponsorSlugs(): string[] {
-  if (cache) return cache;
-
-  for (const root of CANDIDATE_ROOTS) {
-    const abs = join(process.cwd(), root);
-    if (!existsSync(abs)) continue;
-    const slugs = readdirSync(abs)
-      .filter((f) => IMAGE_EXTS.has(extname(f).toLowerCase()))
-      .map((f) => basename(f, extname(f)).toLowerCase());
-    cache = [...new Set(slugs)].sort();
-    return cache;
-  }
-
-  // If we can't scan the directory at runtime, fall back to empty list —
-  // the AI will still work, it just won't know about existing sponsors and
-  // will propose placeholder paths (admin can correct manually).
-  cache = [];
-  return cache;
+  return CANONICAL_SPONSOR_SLUGS;
 }
 
-/**
- * Returns true if the given sponsor slug has a canonical logo file.
- */
 export function hasSponsorLogo(slug: string): boolean {
-  return getSponsorSlugs().includes(slug.toLowerCase());
+  return CANONICAL_SPONSOR_SLUGS.includes(slug.toLowerCase());
 }


### PR DESCRIPTION
## Root cause

Previous `sponsor-registry.ts` used `fs.readdirSync('public/img/sponsors')` at runtime. Next.js's file tracer conservatively interpreted this as "might need files from `public/`" and bundled the entire `public/` tree into the `api/slack/events` serverless function. This pushed the lambda from ~50mb to **318.77mb**, over Vercel's 300mb limit, causing the previous deploy to fail.

## Fix

Replace the runtime fs scan with a hard-coded list of 40 canonical sponsor slugs. When new sponsor logos land in `public/img/sponsors/`, this list must be updated — small maintenance cost, and sponsor additions always go through PR review anyway.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Vercel deploy succeeds (lambda under 300mb)
- [ ] Retry `/event` in Slack channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)