### PR TITLE
fix(slack-bot): disable OpenAI strict JSON schema mode

### DIFF
--- a/lib/slack-bot/ai-extractor.ts
+++ b/lib/slack-bot/ai-extractor.ts
@@ -29,17 +29,22 @@ function getOpenAI(): OpenAI {
  * JSON Schema for structured output — a loose mirror of EventPatchSchema
  * that satisfies OpenAI's strict-mode requirements.
  */
+// Non-strict schema: OpenAI strict mode requires additionalProperties: false
+// on every object, but our `fields` and `event` properties intentionally hold
+// arbitrary EventV3 subfields whose shape the model can pick freely. We rely
+// on Zod validation (EventPatchSchema) to guarantee structural correctness
+// after receiving the output.
 const RESPONSE_JSON_SCHEMA = {
   name: "EventPatch",
-  strict: true,
+  strict: false,
   schema: {
     type: "object",
     properties: {
       op: { type: "string", enum: ["update", "create", "clarify"] },
       eventSlug: { type: "string" },
       summary: { type: "string" },
-      fields: { type: "object", additionalProperties: true },
-      event: { type: "object", additionalProperties: true },
+      fields: { type: "object" },
+      event: { type: "object" },
       imageChecklist: {
         type: "array",
         items: {
@@ -49,14 +54,12 @@ const RESPONSE_JSON_SCHEMA = {
             description: { type: "string" },
             alreadyExists: { type: "boolean" },
           },
-          required: ["path", "description", "alreadyExists"],
-          additionalProperties: false,
+          required: ["path", "description"],
         },
       },
       question: { type: "string" },
     },
-    required: ["op", "eventSlug", "summary", "fields", "event", "imageChecklist", "question"],
-    additionalProperties: false,
+    required: ["op"],
   },
 } as const;
 


### PR DESCRIPTION
## Root cause

First production \`/event\` invocation surfaced:
\`400 Invalid schema for response_format 'EventPatch': In context=('properties', 'fields'), 'additionalProperties' is required to be supplied and to be false.\`

OpenAI strict mode requires \`additionalProperties: false\` on every \`type: object\` and all properties in \`required\`. Our \`EventPatch\` design deliberately carries arbitrary shapes under \`fields\` (update patch) and \`event\` (new event draft) — those can't be tightly constrained without losing flexibility.

## Fix

Switch to non-strict JSON schema. Zod validation (\`EventPatchSchema.safeParse\`) is the real structural safety net — it runs on every model response and rejects any shape that doesn't match the discriminated union.

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [ ] Retry \`/event\` in Slack — expect preview UI or a clean Zod validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)