### PR TITLE
feat(events): Update Google Photos URL for Mind Coach April 2026 event

### DIFF
--- a/lib/data/json/events-custom.json
+++ b/lib/data/json/events-custom.json
@@ -280,7 +280,8 @@
         "category": "workshop",
         "status": "upcoming",
         "isFeatured": true
-      }
+      },
+      "googlePhotosUrl": "https://photos.app.goo.gl/updated-url-for-mind-coach-april-2026"
     },
     {
       "id": 88,


### PR DESCRIPTION
Opened from Slack by <@U094QBSBVGD> via `/event` command.

**Next step:** locally run `gh pr checkout <num>`, place any listed images in `public/img/events/`, push, then merge.
