### PR TITLE
fix(slack-bot): ground /event in channel history + surface access errors

### DIFF
--- a/app/api/slack/events/route.ts
+++ b/app/api/slack/events/route.ts
@@ -67,15 +67,13 @@ export async function POST(request: Request): Promise<Response> {
     return Response.json({ response_type: "ephemeral", text: msg });
   }
 
-  if (!text.trim()) {
-    return Response.json({
-      response_type: "ephemeral",
-      text: "Usage: `/event <free-form description of the update>`",
-    });
-  }
+  // Empty /event means "summarise this channel and propose an update to the
+  // matching event". AI uses channel history as primary source.
+  const userCommand = text.trim() ||
+    "Summarise this channel's recent activity and propose an update to the matching event. Use ONLY concrete facts from the channel messages.";
 
   // Kick off background work that will post the preview via response_url.
-  after(() => processCommand({ channelId, userId, userCommand: text, responseUrl }));
+  after(() => processCommand({ channelId, userId, userCommand, responseUrl }));
 
   return Response.json(buildAckMessage());
 }

--- a/lib/slack-bot/ai-extractor.ts
+++ b/lib/slack-bot/ai-extractor.ts
@@ -83,6 +83,27 @@ Your operation options:
 Always include a concise "summary" (≤ 80 chars) for the preview UI, e.g.
 "Add speaker Danubi Paim to IWD 2026".
 
+CRITICAL NO-FABRICATION RULE:
+Never invent concrete values. URLs (Google Photos links, registration links,
+social media), dates, people's names, job titles, sponsor names, image paths,
+and any other factual field MUST come verbatim from either the admin's /event
+command or the channel messages quoted below. If a value is not present in
+either source, you MUST NOT fill it in — return op="clarify" with a specific
+question naming the missing value (e.g. "What is the Google Photos URL for
+this event? I couldn't find one in the channel."). Do NOT use placeholder
+tokens like "updated-url", "TBD", "example.com", or "…" as values. Do NOT
+paraphrase a URL the admin referenced without pasting it — if you don't have
+the exact string, ask.
+
+CHANNEL-FIRST MODE:
+When the admin's /event text is empty or very short (e.g. just
+"summarize this channel"), treat the channel messages as the primary source
+of truth. Identify which existing event this channel is about (match on
+channel name, topic, and message content against the events array below),
+then propose an update that reflects concrete new facts from the messages —
+added speakers, changed venue, posted recap links, finalised run-sheet,
+etc. Skip fields you don't have direct channel evidence for.
+
 ${context.conventions}
 
 Sponsor inventory (canonical logos at /img/sponsors/<slug>.svg):

--- a/lib/slack-bot/channel-fetcher.ts
+++ b/lib/slack-bot/channel-fetcher.ts
@@ -7,12 +7,14 @@
  * same sort ordering, TypeScript-native.
  */
 
+import { ChannelAccessError } from "./errors";
 import { getSlackClient } from "./slack-client";
 
 interface ChannelSnapshot {
   name: string;
   topic: string;
   messageText: string;
+  messageCount: number;
 }
 
 /** Number of top-level messages to fetch. Keep modest to stay within OpenAI context budget. */
@@ -21,11 +23,21 @@ const MESSAGE_LIMIT = 50;
 export async function fetchChannelSnapshot(channelId: string): Promise<ChannelSnapshot> {
   const slack = getSlackClient();
 
-  const info = await slack.conversations.info({ channel: channelId });
+  let info;
+  try {
+    info = await slack.conversations.info({ channel: channelId });
+  } catch (e) {
+    throw translateSlackError(e, "conversations.info");
+  }
   const name = info.channel?.name ?? channelId;
   const topic = info.channel?.topic?.value ?? "";
 
-  const history = await slack.conversations.history({ channel: channelId, limit: MESSAGE_LIMIT });
+  let history;
+  try {
+    history = await slack.conversations.history({ channel: channelId, limit: MESSAGE_LIMIT });
+  } catch (e) {
+    throw translateSlackError(e, "conversations.history");
+  }
   const messages = history.messages ?? [];
 
   // Fetch thread replies for messages with reply_count > 0
@@ -71,5 +83,35 @@ export async function fetchChannelSnapshot(channelId: string): Promise<ChannelSn
     }
   }
 
-  return { name, topic, messageText: lines.join("\n") };
+  if (all.length === 0) {
+    throw new ChannelAccessError(
+      `channel ${name} (${channelId}) returned 0 usable messages`,
+      `No messages found in #${name}. If the bot was just added, wait a moment and retry. Otherwise make sure the channel actually contains event details and that the bot is a member (run \`/invite @She Sharp Event Bot\`).`,
+    );
+  }
+
+  return { name, topic, messageText: lines.join("\n"), messageCount: all.length };
+}
+
+function translateSlackError(e: unknown, api: string): ChannelAccessError {
+  const code =
+    (e as { data?: { error?: string } })?.data?.error ??
+    (e instanceof Error ? e.message : String(e));
+
+  if (code === "not_in_channel" || code === "channel_not_found") {
+    return new ChannelAccessError(
+      `${api} failed: ${code}`,
+      "I'm not a member of this channel. Please run `/invite @She Sharp Event Bot` in the channel, then try again.",
+    );
+  }
+  if (code === "missing_scope") {
+    return new ChannelAccessError(
+      `${api} failed: missing_scope`,
+      "The bot is missing required Slack scopes (`channels:history` / `groups:history`). Reinstall the app from the Slack admin console.",
+    );
+  }
+  return new ChannelAccessError(
+    `${api} failed: ${code}`,
+    `Could not read channel history (${code}). Check bot membership and scopes.`,
+  );
 }

--- a/lib/slack-bot/errors.ts
+++ b/lib/slack-bot/errors.ts
@@ -54,3 +54,10 @@ export class GitHubError extends SlackBotError {
     this.name = "GitHubError";
   }
 }
+
+export class ChannelAccessError extends SlackBotError {
+  constructor(detail: string, userMessage: string) {
+    super(`Slack channel access failed: ${detail}`, userMessage);
+    this.name = "ChannelAccessError";
+  }
+}


### PR DESCRIPTION
## Summary
Fixes the root cause behind PR #47, which opened a pull request with a fabricated Google Photos URL (`https://photos.app.goo.gl/updated-url-for-mind-coach-april-2026`) even though the invoking Slack channel had no such URL. Three small changes:

- **Surface channel access errors**: `conversations.info` / `conversations.history` failures (`not_in_channel`, `missing_scope`, etc.) now throw `ChannelAccessError` with actionable Slack-safe messages (e.g. *"I'm not a member of this channel. Please run `/invite @She Sharp Event Bot`"*). Empty history is treated the same way.
- **Anti-fabrication prompt rule**: AI must never invent URLs, dates, names, sponsor names, image paths, etc. If the value isn't in `/event` text or channel messages verbatim, it must return `op="clarify"` with a specific question. Placeholder tokens (`updated-url`, `TBD`, `example.com`) explicitly forbidden.
- **Bare `/event` auto-summarise**: Running `/event` with no arguments in an event channel now defaults to *"summarise this channel and propose an update to the matching event"*, using channel history as the primary source of truth.

Scope audit confirmed (via Slack admin UI): `channels:history`, `channels:read`, `chat:write`, `commands`, `groups:history`, `groups:read` all granted, no reinstall required.

## Test plan
- [ ] Run `/event` (no args) in #event--mind-coach-april-2026 (bot already invited) — should produce a preview grounded in real channel messages, or clarify with a specific question.
- [ ] Run `/event` in a channel the bot is NOT a member of — should return the `/invite @She Sharp Event Bot` message instead of opening a bogus PR.
- [ ] Run `/event` with a command like `add new speaker` in a channel where no speaker has been mentioned — should return `op="clarify"` asking for the speaker name, not fabricate one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)