### PR TITLE
fix(events): backfill her-waka-june gallery link + correct past-event status

### DIFF
--- a/lib/data/json/events-custom.json
+++ b/lib/data/json/events-custom.json
@@ -274,11 +274,11 @@
           }
         ],
         "photos": [],
-        "galleryUrl": "",
+        "galleryUrl": "https://photos.app.goo.gl/rQoTv6R9xzU3enTdA",
         "registrationUrl": "https://events.humanitix.com/she-sharp-ministry-of-social-development-academyex-her-waka-june-2026",
         "images": [],
         "category": "workshop",
-        "status": "upcoming",
+        "status": "completed",
         "isFeatured": false
       }
     },
@@ -375,7 +375,7 @@
         "registrationUrl": "https://events.humanitix.com/making-linkedin-work-for-you-with-stuart-little-presented-by-she-sharp-and-aut",
         "images": [],
         "category": "workshop",
-        "status": "upcoming",
+        "status": "completed",
         "isFeatured": false
       },
       "id": 91
@@ -1091,7 +1091,7 @@
         "humanitixUrl": "https://events.humanitix.com/she-sharp-ministry-of-social-development-academyex-her-waka-may-2026",
         "images": [],
         "category": "workshop",
-        "status": "upcoming",
+        "status": "completed",
         "isFeatured": false,
         "refundPolicy": "No refunds"
       }


### PR DESCRIPTION
## Summary

Backfills missing data on existing events by reading their corresponding Slack channels (via `sync-event-from-slack`). Scope kept tight to high-confidence, verifiable gaps.

| Event | Change | Source |
|---|---|---|
| her-waka-june-2026 (#92) | Add `galleryUrl` → `photos.app.goo.gl/rQoTv6R9xzU3enTdA` | `#event-msd-june2-2026`: "share the google photos link to upload it on the website" |
| her-waka-june-2026 (#92) | `status` upcoming → completed | event was 2 Jun 2026 (past), now has a gallery |
| her-waka-may-2026 (#90) | `status` upcoming → completed | event was 5 May 2026 (past), already had a gallery |
| making-linkedin (#91) | `status` upcoming → completed | event was 15 May 2026 (past), already had a gallery |

### Audited, no change needed
- #85 IWD, #87 Candice, #88/#89 Her Waka (Mar/Apr): existing `galleryUrl` already **matches** the canonical "photos for the website" link in their channels.
- #93/#94 Peyvand (13/20 Jun): future events — covers, registration, sponsors, descriptions already complete; no gallery exists yet.
- #86 from-burnout-to-balance: already complete (gallery + 7 photos).

## Test plan
- [x] `npx tsx scripts/verify-image-paths.ts` passes
- [x] Diff is exactly 4 lines (1 gallery + 3 status); #93/#94 left untouched; event count unchanged
- [ ] After deploy, #92 detail page shows the photo gallery and the three events appear under past events

🤖 Generated with [Claude Code](https://claude.com/claude-code)