### PR TITLE
fix(team): use valid TeamRole 'Website Lead' (unblock production build)

### DIFF
--- a/lib/data/team.ts
+++ b/lib/data/team.ts
@@ -67,7 +67,7 @@ export const teamMembers: TeamMember[] = [
   {
     id: 8,
     name: "Chan Meng",
-    roles: ["Ambassador", "Website Team Lead"],
+    roles: ["Ambassador", "Website Lead"],
     linkedin: "https://www.linkedin.com/in/chanmeng666/",
     description:
       "Chan Meng is an AI Agent Architect and full-stack engineer based in Auckland, building at the intersection of AI, cultural technology, and women's health. As She Sharp's Senior Full Stack Engineer and Website Team Lead, she was recruited directly by founder Dr Mahsa Mohaghegh to lead the platform rebuild that now serves 2,200+ members. She holds a Master of Applied Computing with Distinction from Lincoln University, is a UN Women CSW 69 speaker, and received the Outstanding Mentor Award at the 2025 AI Hackathon Festival (AI Forum NZ × She Sharp × AUT). An earliest-ecosystem MCP server author, she architects production AI agents with Next.js, TypeScript, Python, and Kubernetes — and has mentored 800+ women into tech along the way.",


### PR DESCRIPTION
## Summary

`lib/data/team.ts` set Chan Meng's `roles` to `["Ambassador", "Website Team Lead"]`, but `"Website Team Lead"` is **not** a member of the `TeamRole` union in `types/team.ts` (valid value is `"Website Lead"`). This broke the production TypeScript build, and the **Deploy to Vercel** GitHub Action has been failing since commit `a774f7c` — blocking every deploy, including the newly-merged event entries (#66/#69/#68).

Fix: use the valid `"Website Lead"` role. Bio prose left unchanged.

## Test plan
- [x] `npx tsc --noEmit` passes (exit 0)
- [ ] Deploy to Vercel succeeds after merge, publishing the new/updated events