### PR TITLE
fix(events): parseable date for AI Hackathon (fixes missing listing entry)

### DIFF
--- a/lib/data/json/events-custom.json
+++ b/lib/data/json/events-custom.json
@@ -1179,7 +1179,7 @@
       "id": 96,
       "slug": "aotearoa-ai-hackathon-festival-2026",
       "title": "Aotearoa AI Hackathon Festival 2026 — AUT City Campus",
-      "date": "August 7-8, 2026",
+      "date": "August 7, 2026",
       "coverImage": {
         "url": "/img/events/aotearoa-ai-hackathon-festival-2026-cover.png",
         "alt": "Aotearoa AI Hackathon Festival 2026 event cover"
@@ -1192,7 +1192,7 @@
         "url": "https://shesharp.org.nz/events/aotearoa-ai-hackathon-festival-2026",
         "title": "Aotearoa AI Hackathon Festival 2026, hosted by AUT in partnership with She Sharp and the AI Forum",
         "subtitle": "Two-Day AI Hackathon",
-        "date": "August 7-8, 2026",
+        "date": "August 7, 2026",
         "time": "Fri 7 Aug, 5:00pm – Sat 8 Aug 2026 (NZST)",
         "location": {
           "format": "in_person",


### PR DESCRIPTION
## Summary
`"August 7-8, 2026"` is not parseable by `parseDateString` (`new Date(...)` → Invalid Date), so the AI Hackathon event was dropped from the `/events` listing (year filter + upcoming/past partition + sort) and the detail-page countdown broke. The detail page itself still resolved by slug, which masked the issue.

Fix: top-level and detail `date` → `"August 7, 2026"`. The two-day span stays visible via the subtitle ("Two-Day AI Hackathon"), the `time` field ("Fri 7 Aug … – Sat 8 Aug 2026 NZST"), the agenda (Day 1 / Day 2), and the description.

## Test plan
- [x] verify-image-paths passes
- [ ] After deploy: hackathon appears in /events listing and counts as upcoming