### PR TITLE
feat(skill): discovery, incremental reads & durable state for sync-event-from-slack

### DIFF
--- a/.claude/skills/sync-event-from-slack/SKILL.md
+++ b/.claude/skills/sync-event-from-slack/SKILL.md
@@ -12,8 +12,13 @@ download-and-rename work from the developer.
 
 It uses the **She Sharp Event Collector** bot (read-only). The Collector
 token is already in `.env` and has the scopes needed: `channels:history`,
-`channels:read`, `groups:history`, `groups:read`, `files:read`,
-`users:read`, `pins:read`, `bookmarks:read`.
+`channels:read`, `channels:join`, `groups:history`, `groups:read`,
+`files:read`, `users:read`, `pins:read`, `bookmarks:read`.
+
+The skill keeps a committed **memory** at `state/sync-state.json` so it knows
+what it already read, links each channel to its event(s) (slugs differ from
+channel names), reads only deltas, and short-circuits unchanged channels to a
+no-op. See `references/state-and-incremental.md` for the full model.
 
 ## When to apply
 
@@ -55,24 +60,62 @@ is only trustworthy when the user has seen the plan before it executes.
 
 ## Workflow
 
-### Step 1 — Fetch the channel
+This skill runs in two layers. **Layer A (discovery)** finds what changed across
+the whole workspace; **Layer B (per-channel sync)** turns one channel's delta into
+event data and records state. When the user names a single channel you may jump
+straight to Layer B (the fast lane) — but still update state at the end so the next
+run stays incremental.
 
-Run:
+### Step 0 — Discover what changed (Layer A)
+
+Run the triage first whenever the ask is broad ("sync any new events from Slack",
+"check Slack for new events") or you weren't given a specific channel:
 
 ```
-npx tsx .claude/skills/sync-event-from-slack/scripts/fetch-channel.ts <channel-name-or-id>
+npx tsx .claude/skills/sync-event-from-slack/scripts/discover-channels.ts
 ```
 
-Pipe stdout to a file (output can exceed tool context limits):
+It prints a compact table — one row per channel, never message bodies — and writes
+the full machine triage to `.cache/triage.json`. Read the `action` column and act:
+
+- `incremental` → mapped event with new content → Layer B with `--state`.
+- `create?` / `create? (general-signal)` → likely a new event (an event channel
+  with no mapping yet, or a general channel whose new messages scored for event
+  content); confirm the slug with the user, then Layer B in CREATE mode.
+- `join+sync` → run `discover-channels.ts --join` to self-join, then Layer B.
+- `skip→review (new msgs)` → a settled skip that got new activity; glance and
+  decide whether to un-skip.
+- `fingerprint-stale` → the event was edited in the repo since last sync; reconcile.
+- `no-op` / `archived` / `skip` are quiet and hidden by default (`--all` shows them).
+
+Use `--propose` to get fuzzy event-match suggestions for unmapped event channels
+(a backfill aid only — verify, since names and slugs diverge). See
+`references/state-and-incremental.md` for the full action table and semantics.
+
+### Step 1 — Fetch the channel (Layer B)
+
+For a channel already in the manifest, fetch **incrementally** so only new
+messages enter context:
 
 ```
-npx tsx .claude/skills/sync-event-from-slack/scripts/fetch-channel.ts event-x > /tmp/channel.json
+npx tsx .claude/skills/sync-event-from-slack/scripts/fetch-channel.ts <channel> --state > /tmp/channel.json
 ```
 
-The JSON includes: `channel` metadata, `pinned` messages, `bookmarks`,
-a `users` dictionary (id → name), and `messages[]` with each thread
-fully expanded in a `thread` subarray. User IDs inside `text` fields
-stay as `<@U…>` — the dictionary is how you resolve them.
+`--state` reads the channel's watermark + thread state from the manifest and
+returns only the delta. For a brand-new channel (CREATE), omit `--state` for a
+full fetch. Always pipe stdout to a file (output can exceed tool context limits).
+
+The JSON includes a `_meta` block (`mode`, `since`, `newWatermarkTs`,
+`threadState`, `newCount`), `channel` metadata, `pinned` messages (always
+included — canonical), `bookmarks`, a `users` dictionary (id → name), and
+`messages[]` with each thread expanded in a `thread` subarray. In incremental
+mode `messages[]` carries only new top-level messages plus any older thread that
+gained replies (with just its new replies). User IDs inside `text` stay as
+`<@U…>` — the dictionary resolves them.
+
+**No-op fast path:** if `_meta.newCount` is 0 and the event's fingerprint is
+unchanged, there is nothing to sync — emit the UPDATE no-op line (Step 6) and skip
+to recording state (Step 7.4).
 
 ### Step 2 — Identify assets
 
@@ -214,6 +257,22 @@ When the user approves:
    ```
    If it fails, roll back all downloads, revert the JSON patch,
    and tell the user what broke. Never commit with the gate red.
+4. **Record state** so the next run stays incremental. Feed the fetch payload
+   (which carries the new watermark + thread state) to `update-state.ts`:
+   ```
+   # event mapping (repeat --slug/--event-id for a multi-event channel)
+   npx tsx .claude/skills/sync-event-from-slack/scripts/update-state.ts \
+     --from /tmp/channel.json --mapping event --slug <slug> --event-id <id>
+
+   # or, when a channel turns out to carry no site event / is deliberately skipped
+   npx tsx .claude/skills/sync-event-from-slack/scripts/update-state.ts \
+     --from /tmp/channel.json --mapping skip --reason "<why>"
+   npx tsx .claude/skills/sync-event-from-slack/scripts/update-state.ts \
+     --from /tmp/channel.json --mapping none
+   ```
+   `update-state.ts` recomputes the event fingerprint from `events-custom.json`,
+   so run it **after** the JSON patch. Commit `state/sync-state.json` alongside
+   the event change — it is the memory that makes future syncs cheap.
 
 ### Step 8 — Commit
 
@@ -248,8 +307,10 @@ Summarize:
 ## Common failure modes and how to recover
 
 **`not_in_channel` on `conversations.history`** — the Collector bot
-isn't in the channel. Ask the user to run `/invite @She Sharp Event
-Collector` in the channel, then retry.
+isn't in the channel. For a **public** channel, self-join:
+`npx tsx .../discover-channels.ts --join` (uses `channels:join`), then
+retry. For a **private** channel the bot can't self-join — ask the user
+to run `/invite @She Sharp Event Collector` in it.
 
 **`channel_not_found`** — channel name typo, or bot can't see private
 channels it isn't in. Verify with the user.
@@ -268,6 +329,25 @@ the JSON patch before the user sees a broken state.
 
 **`files.filetype` is `jpeg` not `jpg`** — normalize the target
 filename to `.jpg`. Do not re-encode the file.
+
+## State & incremental notes
+
+- **Thread subtlety:** a new reply on an *old* thread does not move the top-level
+  watermark. `--state` catches it via per-thread `replyCount`/`latestReplyTs` in
+  the manifest — so always fetch with `--state` for known channels, not a bare
+  `--since <ts>` that only filters top-level.
+- **General-channel auto-scan:** discovery reads only messages past each general
+  channel's watermark and surfaces a channel only when its event-signal score
+  clears the threshold. Scanned-but-quiet channels still advance their watermark,
+  so they aren't re-scanned. A flagged general channel is a *candidate* — confirm
+  the event and slug with the user before CREATE.
+- **Skip stickiness:** a `skip` mapping stays skipped until new activity arrives
+  (then it shows `skip→review`). Record *why* you skipped in `--reason`.
+- **Fingerprint drift:** if someone edits `events-custom.json` by hand, discovery
+  shows the channel `fingerprint-stale`. Re-sync or re-run `update-state.ts` to
+  re-baseline.
+- **Never hand-edit `state/sync-state.json`** — always go through `update-state.ts`
+  so ordering stays deterministic and the fingerprint is recomputed correctly.
 
 ## What this skill does *not* do
 

--- a/.claude/skills/sync-event-from-slack/references/state-and-incremental.md
+++ b/.claude/skills/sync-event-from-slack/references/state-and-incremental.md
@@ -1,0 +1,94 @@
+# State, discovery, and incremental reads
+
+This skill keeps a memory of what it has already read so it never re-ingests a
+whole channel, and so the channel↔event linkage (which can't be recovered from
+names — slugs differ from channel names) survives between runs.
+
+## The manifest — `state/sync-state.json` (committed)
+
+Keyed by **channel id** (stable across renames). One entry per channel:
+
+```jsonc
+{
+  "version": 1,
+  "channels": {
+    "C0B7K8BFN30": {
+      "name": "event-myob-ai-in-practice-30july-2026",
+      "type": "event",                       // "event" | "general"
+      "mapping": {
+        "kind": "event",
+        "events": [ { "slug": "she-sharp-and-myob-working-smarter", "eventId": 95 } ]
+        //  one channel can feed several events → array
+        //  | { "kind": "skip", "reason": "…" }   (sticky: stays skipped until new activity)
+        //  | { "kind": "none" }                  (scanned, no site event)
+      },
+      "watermarkTs": "1780954764.500039",    // latest top-level ts already processed
+      "threads": { "1780900000.000100": { "replyCount": 4, "latestReplyTs": "1780950000.0001" } },
+      "fingerprint": "sha256:…",             // hash of the mapped event(s) salient fields
+      "lastSyncedAt": "2026-06-09T…Z",
+      "lastSyncedCommit": ""
+    }
+  }
+}
+```
+
+Always written via `scripts/update-state.ts` (atomic, deterministically ordered)
+— never hand-edit it, or git diffs and the no-op short-circuit drift.
+
+## Watermark semantics (and the thread subtlety)
+
+`watermarkTs` is the newest **top-level** message ts already processed. Incremental
+reads return only messages with `ts > watermarkTs`.
+
+**Subtlety:** a new reply on an *old* thread does **not** move the top-level
+watermark — Slack leaves the parent in place. A naive `oldest` filter would miss
+it. So the manifest also stores, per thread parent, its `replyCount` +
+`latestReplyTs`. `fetch-channel.ts --since/--state` does a cheap full metadata
+pass, detects parents whose `replyCount`/`latestReplyTs` grew, and pulls **only
+the new replies** for those threads. New top-level messages get their full thread.
+
+## Fingerprint — the no-op short-circuit
+
+`fingerprint` is a sha256 over the mapped event(s) salient fields in
+`events-custom.json` (title, date, description, speakers, sponsors, sections,
+registration, status, … — excludes `attendees`/`checkedIn`). If a re-sync would
+produce the same event, the fingerprint is unchanged and the channel is a no-op:
+no bodies are read into context. If `events-custom.json` was edited out-of-band,
+discovery flags the channel `fingerprint-stale`.
+
+## Discovery triage contract — `scripts/discover-channels.ts`
+
+Run **first** every sync. Prints a compact table (rows, never message bodies) and
+writes the full machine triage to `.cache/triage.json`. Each row's `action`:
+
+| action | meaning |
+|---|---|
+| `no-op` | nothing new past the watermark — skip |
+| `incremental` | mapped event with new content → sync the delta |
+| `create?` | unmapped/`none` channel with new content → maybe a new event (needs a slug) |
+| `create? (general-signal)` | a general channel whose new messages scored ≥ threshold for event content (evidence line shown) |
+| `join+sync` | event channel the bot isn't in → `--join`, then sync |
+| `skip` / `skip→review (new msgs)` | settled skip; the latter has new activity worth a glance |
+| `fingerprint-stale` | the event was edited in the repo since last sync |
+| `archived` | unreadable; ignored |
+
+Settled states (`no-op*`, `archived`, `skip`) are hidden by default; pass `--all`
+to see them. `--propose` suggests fuzzy event matches for unmapped event channels
+(backfill aid only — verify before trusting; names and slugs diverge). `--join`
+self-joins public event channels the bot isn't in (`channels:join` scope).
+
+General channels are auto-scanned: only messages past the watermark are read, and
+only channels scoring ≥ the signal threshold surface — chatter never reaches
+Claude. A scanned-but-quiet channel still advances its watermark so it isn't
+re-scanned next run.
+
+## Token economics
+
+- Discovery = one small table → Claude learns the whole workspace in one read.
+- `--since`/`--state` → only **new** messages enter context after the first sync.
+- Fingerprint no-op → unchanged channels cost ≈0 Claude tokens.
+- In-script signal detection → only event-looking general channels surface.
+- `.cache/` (gitignored) dedups full fetches within a session.
+
+Slack API calls are cheap and stay out of Claude's context; the scripts do the
+metadata legwork so Claude only ever reads deltas.

--- a/.claude/skills/sync-event-from-slack/scripts/discover-channels.ts
+++ b/.claude/skills/sync-event-from-slack/scripts/discover-channels.ts
@@ -1,0 +1,340 @@
+/**
+ * Triage front door for the sync-event-from-slack skill.
+ *
+ * Lists every channel the Collector bot can see, cross-references the committed
+ * manifest (state/sync-state.json), and prints a COMPACT triage — one row per
+ * channel, never message bodies — so Claude learns the whole workspace state
+ * from a single cheap read and only drills into channels that actually changed.
+ *
+ * For each channel it determines: type (event vs general), bot membership,
+ * known mapping, whether there's new content past the stored watermark, and —
+ * for general channels — an in-script event-signal score (so chatter never
+ * reaches Claude). A per-row `action` hint summarizes what to do next.
+ *
+ * Usage:
+ *   npx tsx .../discover-channels.ts            # actionable triage (+ no-op count)
+ *   npx tsx .../discover-channels.ts --all      # include no-op rows
+ *   npx tsx .../discover-channels.ts --propose   # suggest event matches for unmapped event channels (backfill)
+ *   npx tsx .../discover-channels.ts --join      # self-join public event channels the bot isn't in
+ *
+ * Full machine-readable triage is always written to .cache/triage.json.
+ */
+
+import "dotenv/config";
+import { WebClient } from "@slack/web-api";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  CACHE_DIR,
+  classifyChannel,
+  detectEventSignal,
+  fingerprintForMapping,
+  loadEvents,
+  loadManifest,
+  SIGNAL_THRESHOLD,
+  type ChannelType,
+  type Mapping,
+} from "./state-lib.ts";
+
+const token = process.env.SLACK_BOT_TOKEN;
+if (!token) {
+  console.error("SLACK_BOT_TOKEN is not set in .env");
+  process.exit(1);
+}
+const slack = new WebClient(token);
+
+const flags = new Set(process.argv.slice(2).filter((a) => a.startsWith("--")));
+const showAll = flags.has("--all");
+const doPropose = flags.has("--propose");
+const doJoin = flags.has("--join");
+
+interface SlackChannel {
+  id: string;
+  name: string;
+  is_member: boolean;
+  is_archived: boolean;
+}
+
+async function listChannels(): Promise<SlackChannel[]> {
+  const out: SlackChannel[] = [];
+  let cursor: string | undefined;
+  do {
+    const r = await slack.conversations.list({
+      types: "public_channel,private_channel",
+      limit: 1000,
+      cursor,
+      exclude_archived: false,
+    });
+    for (const c of r.channels ?? []) {
+      out.push({
+        id: c.id!,
+        name: c.name ?? "",
+        is_member: !!(c as any).is_member,
+        is_archived: !!(c as any).is_archived,
+      });
+    }
+    cursor = r.response_metadata?.next_cursor || undefined;
+  } while (cursor);
+  return out;
+}
+
+/** Messages strictly newer than `oldest` (exclusive). Returns text + file flag. */
+async function newMessagesSince(
+  channelId: string,
+  oldest: string | undefined,
+  cap = 60,
+): Promise<{ count: number; texts: string[]; hasImage: boolean; latestTs: string }> {
+  const texts: string[] = [];
+  let hasImage = false;
+  let count = 0;
+  let latestTs = oldest ?? "0";
+  let cursor: string | undefined;
+  try {
+    do {
+      const r = await slack.conversations.history({
+        channel: channelId,
+        oldest: oldest && oldest !== "0" ? oldest : undefined,
+        limit: 200,
+        cursor,
+      });
+      for (const m of r.messages ?? []) {
+        const ts = (m as any).ts as string;
+        if (oldest && Number(ts) <= Number(oldest)) continue;
+        count++;
+        if ((m as any).text) texts.push((m as any).text);
+        if (((m as any).files ?? []).some((f: any) => /^image\//.test(f.mimetype ?? ""))) hasImage = true;
+        if (Number(ts) > Number(latestTs)) latestTs = ts;
+        if (count >= cap) break;
+      }
+      cursor = count >= cap ? undefined : r.response_metadata?.next_cursor || undefined;
+    } while (cursor);
+  } catch {
+    /* not_in_channel etc. — treated as no readable content */
+  }
+  return { count, texts, hasImage, latestTs };
+}
+
+// --- fuzzy event matching for backfill ------------------------------------
+const STOP = new Set([
+  "event", "events", "she", "sharp", "shesharp", "the", "and", "with", "for", "of", "a", "an",
+  "to", "in", "on", "at", "by", "2024", "2025", "2026", "2027",
+  "jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "sept", "oct", "nov", "dec",
+  "january", "february", "march", "april", "june", "july", "august", "september", "october",
+  "november", "december", "series", "talk", "session", "workshop",
+]);
+
+function tokens(s: string): Set<string> {
+  return new Set(
+    (s.toLowerCase().match(/[a-z0-9]+/g) ?? []).filter((t) => t.length > 2 && !STOP.has(t)),
+  );
+}
+
+function bestEventMatch(channelName: string, events: any[]): { slug: string; id: number; score: number } | null {
+  const ct = tokens(channelName);
+  let best: { slug: string; id: number; score: number } | null = null;
+  for (const e of events) {
+    const et = tokens(`${e.slug} ${e.title}`);
+    let overlap = 0;
+    for (const t of ct) if (et.has(t)) overlap++;
+    const score = ct.size ? overlap / ct.size : 0;
+    if (score > 0 && (!best || score > best.score)) best = { slug: e.slug, id: e.id, score };
+  }
+  return best && best.score >= 0.34 ? best : null;
+}
+
+// --- main ------------------------------------------------------------------
+
+interface Row {
+  type: ChannelType;
+  name: string;
+  id: string;
+  member: boolean;
+  archived: boolean;
+  mapping: Mapping | null;
+  hasNew: boolean;
+  newCount: number;
+  latestTs: string;
+  signalScore: number;
+  signalHits: string[];
+  evidence: string;
+  fingerprintStale: boolean;
+  propose: { slug: string; id: number; score: number } | null;
+  action: string;
+}
+
+function decideAction(r: Row): string {
+  if (r.archived) return "archived";
+  if (r.type === "event") {
+    if (!r.member) return "join+sync";
+    if (r.mapping?.kind === "skip") return r.hasNew ? "skip→review (new msgs)" : "skip";
+    if (!r.mapping || r.mapping.kind === "none") {
+      // Unseen or "scanned, no site event": only resurface on new activity.
+      if (!r.hasNew) return "no-op";
+      return r.propose ? `create? (≈${r.propose.slug})` : "create?";
+    }
+    // mapped to an event
+    if (r.fingerprintStale) return "fingerprint-stale (event edited)";
+    return r.hasNew ? "incremental" : "no-op";
+  }
+  // general
+  if (!r.member) return "no-op (not member)";
+  if (r.signalScore >= SIGNAL_THRESHOLD) return "create? (general-signal)";
+  return r.hasNew ? "no-op (no signal)" : "no-op";
+}
+
+async function main() {
+  const channels = await listChannels();
+  const manifest = loadManifest();
+  const events = loadEvents();
+
+  if (doJoin) {
+    for (const c of channels) {
+      if (classifyChannel(c.name) === "event" && !c.is_member && !c.is_archived) {
+        try {
+          await slack.conversations.join({ channel: c.id });
+          console.error(`joined #${c.name}`);
+        } catch (e: any) {
+          console.error(`join failed #${c.name}: ${e?.data?.error ?? e?.message}`);
+        }
+      }
+    }
+  }
+
+  const rows: Row[] = [];
+  for (const c of channels) {
+    const type = classifyChannel(c.name);
+    const cs = manifest.channels[c.id];
+    const mapping = cs?.mapping ?? null;
+    const watermark = cs?.watermarkTs;
+
+    let hasNew = false;
+    let newCount = 0;
+    let signalScore = 0;
+    let signalHits: string[] = [];
+    let evidence = "";
+    let latestTs = watermark ?? "0";
+
+    // Only read history for member, non-archived channels (others are unreadable).
+    if (c.is_member && !c.is_archived) {
+      // Cheap 1-message peek first: a quiet channel costs a single API call.
+      let peek = "0";
+      try {
+        const r = await slack.conversations.history({ channel: c.id, limit: 1 });
+        peek = (r.messages?.[0] as any)?.ts ?? "0";
+      } catch {
+        /* not_in_channel etc. */
+      }
+      latestTs = peek;
+      const hasWatermark = !!watermark && watermark !== "0";
+      const newByTs = !hasWatermark || Number(peek) > Number(watermark);
+
+      if (newByTs) {
+        // Only pull bodies when something is actually new. Mapped events don't
+        // need bodies here (the per-channel sync reads the delta); general and
+        // unmapped channels do, to count + score for event signals.
+        const mappedEvent = mapping?.kind === "event" || mapping?.kind === "skip";
+        const needBodies = type === "general" || !mappedEvent;
+        if (needBodies) {
+          const res = await newMessagesSince(c.id, watermark);
+          newCount = res.count;
+          hasNew = res.count > 0;
+          if (Number(res.latestTs) > Number(latestTs)) latestTs = res.latestTs;
+          if (type === "general" && res.texts.length) {
+            const sig = detectEventSignal(res.texts);
+            signalScore = sig.score + (res.hasImage ? 1 : 0);
+            signalHits = sig.hits;
+            evidence = sig.evidence;
+          }
+        } else {
+          hasNew = true;
+          newCount = -1; // -1 = "some" (not counted)
+        }
+      }
+    }
+
+    // Fingerprint freshness for mapped events (did events-custom.json change?).
+    let fingerprintStale = false;
+    if (mapping?.kind === "event") {
+      const current = fingerprintForMapping(mapping);
+      fingerprintStale = !!cs && cs.fingerprint !== "" && current !== "" && current !== cs.fingerprint;
+    }
+
+    const propose =
+      doPropose && type === "event" && (!mapping || mapping.kind === "none")
+        ? bestEventMatch(c.name, events)
+        : null;
+
+    const row: Row = {
+      type,
+      name: c.name,
+      id: c.id,
+      member: c.is_member,
+      archived: c.is_archived,
+      mapping,
+      hasNew,
+      newCount,
+      latestTs,
+      signalScore,
+      signalHits,
+      evidence,
+      fingerprintStale,
+      propose,
+      action: "",
+    };
+    row.action = decideAction(row);
+    rows.push(row);
+  }
+
+  // Persist full machine triage.
+  mkdirSync(CACHE_DIR, { recursive: true });
+  const triagePath = resolve(CACHE_DIR, "triage.json");
+  writeFileSync(triagePath, JSON.stringify({ generatedAt: new Date().toISOString(), rows }, null, 2));
+
+  // Compact human triage to stdout. Settled states (no-op / archived / skip)
+  // are quiet — only genuinely new or unresolved channels need attention.
+  const isQuiet = (a: string) => a.startsWith("no-op") || a === "archived" || a === "skip";
+  const quiet = rows.filter((r) => isQuiet(r.action));
+  const actionable = rows.filter((r) => !isQuiet(r.action));
+  const shown = showAll ? rows : actionable;
+  shown.sort((a, b) => a.type.localeCompare(b.type) || a.name.localeCompare(b.name));
+
+  const lines: string[] = [];
+  lines.push(`Channels: ${rows.length} total — ${actionable.length} need attention, ${quiet.length} quiet`);
+  lines.push("");
+  lines.push(pad("TYPE", 8) + pad("CHANNEL", 44) + pad("MBR", 5) + pad("NEW", 5) + pad("SIG", 5) + "ACTION / MAPPING");
+  for (const r of shown) {
+    const map =
+      r.mapping?.kind === "event"
+        ? `→${r.mapping.events.map((e) => e.slug).join(", ")}`
+        : r.mapping?.kind === "skip"
+          ? `skip:${r.mapping.reason}`
+          : "";
+    const newCol = r.newCount === -1 ? "yes" : r.newCount > 0 ? String(r.newCount) : "-";
+    const sigCol = r.signalScore > 0 ? String(r.signalScore) : "-";
+    lines.push(
+      pad(r.type, 8) +
+        pad(r.name.slice(0, 42), 44) +
+        pad(r.member ? "yes" : "no", 5) +
+        pad(newCol, 5) +
+        pad(sigCol, 5) +
+        `${r.action}${map ? "  " + map : ""}`,
+    );
+    if (r.evidence && r.signalScore >= SIGNAL_THRESHOLD) {
+      lines.push(pad("", 12) + `↳ ${r.signalHits.join(",")}: "${r.evidence}"`);
+    }
+    if (r.propose) lines.push(pad("", 12) + `↳ propose →${r.propose.slug} (id ${r.propose.id}, ${(r.propose.score * 100) | 0}%)`);
+  }
+  if (!showAll && quiet.length) lines.push("", `(${quiet.length} quiet channels hidden — pass --all to show)`);
+  lines.push("", `Full machine triage: ${triagePath}`);
+
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+function pad(s: string, w: number): string {
+  return s.length >= w ? s.slice(0, w - 1) + " " : s + " ".repeat(w - s.length);
+}
+
+main().catch((e) => {
+  console.error("FATAL:", e?.data ?? e?.message ?? e);
+  process.exit(1);
+});

--- a/.claude/skills/sync-event-from-slack/scripts/fetch-channel.ts
+++ b/.claude/skills/sync-event-from-slack/scripts/fetch-channel.ts
@@ -1,28 +1,43 @@
 /**
- * Dump everything the She Sharp Event Collector bot can see in a channel.
+ * Dump what the She Sharp Event Collector bot can see in a channel.
  *
  * Emits a single JSON object on stdout. Runs from the repo root and reads
  * SLACK_BOT_TOKEN from .env via dotenv.
  *
  * Usage:
- *   npx tsx .claude/skills/sync-event-from-slack/scripts/fetch-channel.ts <channelNameOrId>
+ *   # Full fetch (default — back-compatible)
+ *   npx tsx .../fetch-channel.ts <channelNameOrId>
+ *
+ *   # Incremental: only messages/threads new since a watermark ts
+ *   npx tsx .../fetch-channel.ts <channelNameOrId> --since 1717300000.123456
+ *
+ *   # Incremental using the watermark stored in the manifest for this channel
+ *   npx tsx .../fetch-channel.ts <channelNameOrId> --state
+ *
+ *   # Reuse a same-session cached payload when the channel hasn't changed
+ *   npx tsx .../fetch-channel.ts <channelNameOrId> --use-cache
  *
  * Output shape:
  * {
+ *   _meta:     { mode, since, newWatermarkTs, threadState, newCount, fromCache },
  *   channel:   { id, name, purpose, topic, num_members, created, is_archived },
- *   pinned:    [ { ts, user_id, user_name, text, files[], links[] } ],
+ *   pinned:    [ NormalizedMessage ],   // always included (canonical)
  *   bookmarks: [ { title, link, emoji, type, rank } ],
  *   users:     { [user_id]: { real_name, display_name } },
- *   messages:  [ NormalizedMessage ]
+ *   messages:  [ NormalizedMessage ]    // in incremental mode: only new/changed
  * }
  *
- * NormalizedMessage =
- *   { ts, iso, user_id, user_name, text, subtype, reactions[], files[], links[],
- *     thread: NormalizedMessage[] }
+ * `_meta.threadState` is the full current per-thread { replyCount, latestReplyTs }
+ * map — feed it (with newWatermarkTs) to update-state.ts so the next run reads
+ * only the delta. In incremental mode `messages[]` carries only new top-level
+ * messages plus any older thread that gained replies (with just its new replies).
  */
 
 import "dotenv/config";
 import { WebClient } from "@slack/web-api";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { CACHE_DIR, loadManifest, type ThreadState } from "./state-lib.ts";
 
 const token = process.env.SLACK_BOT_TOKEN;
 if (!token) {
@@ -31,11 +46,22 @@ if (!token) {
 }
 const slack = new WebClient(token);
 
-const raw = process.argv[2];
+// ---- arg parsing ----------------------------------------------------------
+const argv = process.argv.slice(2);
+const flags = new Set(argv.filter((a) => a.startsWith("--")).map((a) => a.split("=")[0]));
+const sinceFlag = argv.find((a) => a.startsWith("--since"));
+const positional = argv.filter((a) => !a.startsWith("--"));
+const raw = positional[0];
 if (!raw) {
-  console.error("Usage: fetch-channel.ts <channelNameOrId>");
+  console.error("Usage: fetch-channel.ts <channelNameOrId> [--since <ts>] [--state] [--use-cache]");
   process.exit(2);
 }
+let sinceArg: string | undefined;
+if (sinceFlag) {
+  sinceArg = sinceFlag.includes("=") ? sinceFlag.split("=")[1] : argv[argv.indexOf(sinceFlag) + 1];
+}
+const useState = flags.has("--state");
+const useCache = flags.has("--use-cache");
 
 async function resolveChannel(nameOrId: string): Promise<string> {
   if (/^[CGD][A-Z0-9]+$/i.test(nameOrId)) return nameOrId; // looks like an ID
@@ -135,18 +161,25 @@ function normalize(m: any, userName: string): NormalizedMessage {
   };
 }
 
-async function fetchThread(channelId: string, parent: NormalizedMessage, rawCount: number): Promise<void> {
+/**
+ * Fetch thread replies for a parent. When `sinceReplyTs` is given, only replies
+ * strictly newer than it are returned — this is what lets us pick up a fresh
+ * reply on an OLD thread (whose parent ts is below the top-level watermark)
+ * without re-reading the whole thread.
+ */
+async function fetchThread(
+  channelId: string,
+  parent: NormalizedMessage,
+  rawCount: number,
+  sinceReplyTs?: string,
+): Promise<void> {
   if (!rawCount || rawCount <= 0) return;
   let cursor: string | undefined;
   do {
-    const r = await slack.conversations.replies({
-      channel: channelId,
-      ts: parent.ts,
-      limit: 200,
-      cursor,
-    });
+    const r = await slack.conversations.replies({ channel: channelId, ts: parent.ts, limit: 200, cursor });
     const rest = (r.messages ?? []).slice(1); // drop parent duplicate
     for (const m of rest) {
+      if (sinceReplyTs && Number((m as any).ts) <= Number(sinceReplyTs)) continue;
       const uname = await resolveUser((m as any).user);
       parent.thread.push(normalize(m, uname));
     }
@@ -154,8 +187,46 @@ async function fetchThread(channelId: string, parent: NormalizedMessage, rawCoun
   } while (cursor);
 }
 
+function cachePath(channelId: string): string {
+  return resolve(CACHE_DIR, `${channelId}.json`);
+}
+
+/** One-message peek to learn the channel's current latest ts cheaply. */
+async function peekLatestTs(channelId: string): Promise<string> {
+  const r = await slack.conversations.history({ channel: channelId, limit: 1 });
+  return (r.messages?.[0] as any)?.ts ?? "0";
+}
+
 async function main() {
   const channelId = await resolveChannel(raw);
+
+  // Resolve the incremental watermark + prior thread state.
+  let since = sinceArg;
+  let priorThreads: Record<string, ThreadState> = {};
+  if (useState) {
+    const manifest = loadManifest();
+    const cs = manifest.channels[channelId];
+    if (cs) {
+      since = since ?? cs.watermarkTs;
+      priorThreads = cs.threads ?? {};
+    }
+  }
+  const incremental = !!since;
+
+  // Session cache: skip the full fetch when the channel hasn't moved.
+  if (useCache && existsSync(cachePath(channelId))) {
+    try {
+      const cached = JSON.parse(readFileSync(cachePath(channelId), "utf8"));
+      const latest = await peekLatestTs(channelId);
+      if (cached._meta?.newWatermarkTs === latest && !incremental) {
+        cached._meta.fromCache = true;
+        process.stdout.write(JSON.stringify(cached, null, 2));
+        return;
+      }
+    } catch {
+      /* fall through to a live fetch */
+    }
+  }
 
   // channel metadata
   const infoRes = await slack.conversations.info({ channel: channelId, include_num_members: true });
@@ -170,7 +241,7 @@ async function main() {
     is_archived: !!c?.is_archived,
   };
 
-  // pinned
+  // pinned (always — canonical regardless of watermark)
   const pinnedItems: NormalizedMessage[] = [];
   try {
     const p = await slack.pins.list({ channel: channelId });
@@ -195,7 +266,7 @@ async function main() {
     }));
   } catch {}
 
-  // full history with threads
+  // Full raw history (cheap API). Threads are expanded selectively below.
   const rawMessages: any[] = [];
   let cursor: string | undefined;
   do {
@@ -205,19 +276,67 @@ async function main() {
   } while (cursor);
   rawMessages.sort((a, b) => Number(a.ts) - Number(b.ts));
 
+  // Build the full current thread-state map (every parent that has replies),
+  // independent of what we choose to emit — the next run needs the complete map.
+  const threadState: Record<string, ThreadState> = {};
+  for (const rm of rawMessages) {
+    if ((rm.reply_count ?? 0) > 0) {
+      threadState[rm.ts] = {
+        replyCount: rm.reply_count,
+        latestReplyTs: rm.latest_reply ?? rm.ts,
+      };
+    }
+  }
+
+  const newWatermarkTs = rawMessages.length ? rawMessages[rawMessages.length - 1].ts : (since ?? "0");
+
+  // Decide which parents to emit.
   const messages: NormalizedMessage[] = [];
   for (const rm of rawMessages) {
+    const isNewTopLevel = !incremental || Number(rm.ts) > Number(since);
+    const prior = priorThreads[rm.ts];
+    const threadGrew =
+      incremental &&
+      (rm.reply_count ?? 0) > 0 &&
+      prior != null &&
+      ((rm.reply_count ?? 0) > prior.replyCount || Number(rm.latest_reply ?? 0) > Number(prior.latestReplyTs));
+
+    if (!isNewTopLevel && !threadGrew) continue;
+
     const uname = await resolveUser(rm.user);
     const n = normalize(rm, uname);
-    await fetchThread(channelId, n, rm.reply_count ?? 0);
+    // New top-level → full thread. Old-but-grown thread → only the new replies.
+    const sinceReplyTs = isNewTopLevel ? undefined : prior?.latestReplyTs;
+    await fetchThread(channelId, n, rm.reply_count ?? 0, sinceReplyTs);
     messages.push(n);
   }
 
   const users: Record<string, { real_name: string; display_name: string }> = {};
   for (const [id, v] of userCache.entries()) users[id] = v;
 
-  // stable serialization
-  process.stdout.write(JSON.stringify({ channel, pinned: pinnedItems, bookmarks, users, messages }, null, 2));
+  const payload = {
+    _meta: {
+      mode: incremental ? "incremental" : "full",
+      since: since ?? null,
+      newWatermarkTs,
+      threadState,
+      newCount: messages.length,
+      fromCache: false,
+    },
+    channel,
+    pinned: pinnedItems,
+    bookmarks,
+    users,
+    messages,
+  };
+
+  // Always refresh the session cache with the latest full/delta payload.
+  try {
+    mkdirSync(CACHE_DIR, { recursive: true });
+    writeFileSync(cachePath(channelId), JSON.stringify(payload, null, 2));
+  } catch {}
+
+  process.stdout.write(JSON.stringify(payload, null, 2));
 }
 
 main().catch((e) => {

--- a/.claude/skills/sync-event-from-slack/scripts/state-lib.ts
+++ b/.claude/skills/sync-event-from-slack/scripts/state-lib.ts
@@ -1,0 +1,248 @@
+/**
+ * Shared helpers for the sync-event-from-slack skill's stateful, incremental
+ * pipeline. Imported by discover-channels.ts, fetch-channel.ts, and
+ * update-state.ts so the manifest schema, fingerprint, channel classification,
+ * and event-signal detection stay identical across all three.
+ *
+ * Path model: every script in this skill is run from the repo root. The skill
+ * root is resolved relative to this file (…/.claude/skills/sync-event-from-slack)
+ * so the state + cache locations are stable regardless of cwd.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+/** …/.claude/skills/sync-event-from-slack */
+export const SKILL_ROOT = resolve(SCRIPT_DIR, "..");
+export const STATE_PATH = resolve(SKILL_ROOT, "state", "sync-state.json");
+export const CACHE_DIR = resolve(SKILL_ROOT, ".cache");
+/** events file, relative to the repo root (two levels above .claude) */
+export const EVENTS_PATH = resolve(SKILL_ROOT, "..", "..", "..", "lib", "data", "json", "events-custom.json");
+
+// ---------------------------------------------------------------------------
+// Manifest types
+// ---------------------------------------------------------------------------
+
+export type ChannelType = "event" | "general";
+
+export type Mapping =
+  // One channel can feed more than one event (e.g. a "13 & 20 June" planning
+  // channel, or a month split into multiple sessions), hence an array.
+  | { kind: "event"; events: { slug: string; eventId: number }[] }
+  | { kind: "skip"; reason: string }
+  | { kind: "none" };
+
+export interface ThreadState {
+  replyCount: number;
+  latestReplyTs: string;
+}
+
+export interface ChannelState {
+  name: string;
+  type: ChannelType;
+  mapping: Mapping;
+  watermarkTs: string; // latest top-level message ts already processed
+  threads: Record<string, ThreadState>; // parentTs -> thread watermark
+  fingerprint: string; // sha256:… of the mapped event's salient fields ("" when none)
+  lastSyncedAt: string;
+  lastSyncedCommit: string;
+}
+
+export interface Manifest {
+  version: number;
+  channels: Record<string, ChannelState>;
+}
+
+const EMPTY_MANIFEST: Manifest = { version: 1, channels: {} };
+
+export function loadManifest(): Manifest {
+  if (!existsSync(STATE_PATH)) return structuredClone(EMPTY_MANIFEST);
+  try {
+    const parsed = JSON.parse(readFileSync(STATE_PATH, "utf8")) as Manifest;
+    if (!parsed.channels) parsed.channels = {};
+    if (!parsed.version) parsed.version = 1;
+    return parsed;
+  } catch {
+    return structuredClone(EMPTY_MANIFEST);
+  }
+}
+
+/**
+ * Write the manifest deterministically: channels sorted by id, keys stably
+ * ordered, trailing newline. Atomic via temp-file rename so a crash can't leave
+ * a half-written manifest. Stable serialization keeps git diffs minimal.
+ */
+export function saveManifest(m: Manifest): void {
+  mkdirSync(dirname(STATE_PATH), { recursive: true });
+  const ordered: Manifest = { version: m.version ?? 1, channels: {} };
+  for (const id of Object.keys(m.channels).sort()) {
+    const c = m.channels[id];
+    ordered.channels[id] = {
+      name: c.name,
+      type: c.type,
+      mapping: c.mapping,
+      watermarkTs: c.watermarkTs,
+      threads: sortThreads(c.threads),
+      fingerprint: c.fingerprint,
+      lastSyncedAt: c.lastSyncedAt,
+      lastSyncedCommit: c.lastSyncedCommit,
+    };
+  }
+  const tmp = `${STATE_PATH}.tmp`;
+  writeFileSync(tmp, JSON.stringify(ordered, null, 2) + "\n");
+  renameSync(tmp, STATE_PATH);
+}
+
+function sortThreads(threads: Record<string, ThreadState>): Record<string, ThreadState> {
+  const out: Record<string, ThreadState> = {};
+  for (const ts of Object.keys(threads ?? {}).sort((a, b) => Number(a) - Number(b))) {
+    out[ts] = { replyCount: threads[ts].replyCount, latestReplyTs: threads[ts].latestReplyTs };
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Fingerprint — detects whether a mapped event's salient content changed.
+// Computed from events-custom.json, not Slack, so a re-sync that produces the
+// same event is a no-op even if Slack chatter moved on.
+// ---------------------------------------------------------------------------
+
+/** Pull the entry with the given slug out of events-custom.json (or null). */
+export function findEventBySlug(slug: string): any | null {
+  try {
+    const data = JSON.parse(readFileSync(EVENTS_PATH, "utf8"));
+    return (data.events ?? []).find((e: any) => e.slug === slug) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function loadEvents(): any[] {
+  try {
+    return JSON.parse(readFileSync(EVENTS_PATH, "utf8")).events ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Deterministic fingerprint of the fields this skill actually writes. Excludes
+ * post-event reconciliation fields (attendees, checkedIn) and editor-only churn
+ * we don't want to trigger a re-sync.
+ */
+export function fingerprintEvent(event: any | null): string {
+  if (!event) return "";
+  const d = event.detailPageData ?? {};
+  const salient = {
+    title: event.title ?? "",
+    date: event.date ?? "",
+    shortDescription: event.shortDescription ?? "",
+    cover: event.coverImage?.url ?? "",
+    subtitle: d.subtitle ?? "",
+    time: d.time ?? "",
+    location: d.location ?? {},
+    fullDescription: d.fullDescription ?? [],
+    speakers: d.speakers ?? {},
+    sponsors: d.sponsors ?? {},
+    specialSections: d.specialSections ?? [],
+    registrationUrl: d.registrationUrl ?? "",
+    galleryUrl: d.galleryUrl ?? "",
+    category: d.category ?? "",
+    status: d.status ?? "",
+    isFeatured: d.isFeatured ?? false,
+  };
+  const hash = createHash("sha256").update(JSON.stringify(salient)).digest("hex");
+  return `sha256:${hash}`;
+}
+
+/**
+ * Combined fingerprint for a mapping. For an event mapping, hashes every mapped
+ * event's salient fields together so a change in any of them invalidates the
+ * no-op. Non-event mappings have no fingerprint ("").
+ */
+export function fingerprintForMapping(mapping: Mapping): string {
+  if (mapping.kind !== "event") return "";
+  const parts = mapping.events
+    .map((e) => `${e.slug}:${fingerprintEvent(findEventBySlug(e.slug))}`)
+    .sort();
+  return `sha256:${createHash("sha256").update(parts.join("|")).digest("hex")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Channel classification
+// ---------------------------------------------------------------------------
+
+/** Event-planning channels are named `event…` by convention in this workspace. */
+export function classifyChannel(name: string): ChannelType {
+  return /^event[-_]?/i.test(name) ? "event" : "general";
+}
+
+// ---------------------------------------------------------------------------
+// Event-signal detection for general channels. Runs in-script over message text
+// so only channels that actually look like they carry an event reach Claude.
+// ---------------------------------------------------------------------------
+
+const SIGNAL_PATTERNS: { name: string; re: RegExp; weight: number }[] = [
+  { name: "humanitix", re: /humanitix\.com/i, weight: 3 },
+  { name: "eventbrite", re: /eventbrite\.[a-z.]+/i, weight: 3 },
+  { name: "luma", re: /\b(?:lu\.ma|luma\.com)\b/i, weight: 3 },
+  { name: "register", re: /\b(?:register(?:ed|ing)?|registration|sign[\s-]?up|RSVP)\b/i, weight: 1 },
+  { name: "ticket", re: /\b(?:tickets?|book\s+your\s+spot|seats?)\b/i, weight: 1 },
+  { name: "speaker", re: /\b(?:speaker|panellist|panelist|keynote|guest\s+speaker)\b/i, weight: 1 },
+  { name: "venue", re: /\b(?:venue|doors\s+open|agenda|line[\s-]?up)\b/i, weight: 1 },
+  {
+    name: "date",
+    re: /\b(\d{1,2}(?:st|nd|rd|th)?\s+)?(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+\d{1,2}?,?\s*20\d\d\b/i,
+    weight: 1,
+  },
+  { name: "time", re: /\b\d{1,2}(?::\d{2})?\s*(?:am|pm)\b/i, weight: 1 },
+];
+
+const SIGNAL_THRESHOLD = 3;
+
+export interface SignalResult {
+  score: number;
+  hits: string[];
+  evidence: string; // single-line snippet of the strongest message
+}
+
+/**
+ * Score an array of message text bodies for event-likeness. Returns a compact
+ * result; callers only surface it to Claude when score >= SIGNAL_THRESHOLD.
+ */
+export function detectEventSignal(texts: string[]): SignalResult {
+  let score = 0;
+  const hits = new Set<string>();
+  let best = "";
+  let bestLocal = 0;
+  for (const raw of texts) {
+    const text = raw ?? "";
+    let local = 0;
+    for (const p of SIGNAL_PATTERNS) {
+      if (p.re.test(text)) {
+        score += p.weight;
+        local += p.weight;
+        hits.add(p.name);
+      }
+    }
+    if (local > bestLocal) {
+      bestLocal = local;
+      best = text;
+    }
+  }
+  const evidence = best.replace(/\s+/g, " ").trim().slice(0, 160);
+  return { score, hits: [...hits], evidence };
+}
+
+export { SIGNAL_THRESHOLD };
+
+// ---------------------------------------------------------------------------
+// Misc
+// ---------------------------------------------------------------------------
+
+export function nowIso(): string {
+  return new Date().toISOString();
+}

--- a/.claude/skills/sync-event-from-slack/scripts/update-state.ts
+++ b/.claude/skills/sync-event-from-slack/scripts/update-state.ts
@@ -1,0 +1,129 @@
+/**
+ * Atomically record one channel's sync state into the committed manifest
+ * (state/sync-state.json). Keeps Claude from hand-editing the manifest, and
+ * computes the deterministic content fingerprint from events-custom.json so the
+ * next run can short-circuit unchanged events to a no-op.
+ *
+ * The watermark + thread map come straight from a fetch-channel.ts payload via
+ * --from, so the normal flow is:
+ *
+ *   npx tsx .../fetch-channel.ts <ch> --state > out.json
+ *   # …sync the event into events-custom.json…
+ *   npx tsx .../update-state.ts --from out.json --mapping event --slug <slug> --event-id <id>
+ *
+ * Mapping forms:
+ *   --mapping event  --slug <slug> --event-id <n>            (repeatable for multi-event channels)
+ *   --mapping skip   --reason "<why>"
+ *   --mapping none
+ *
+ * Other flags:
+ *   --from <fetch-output.json>   pull channel id/name, watermark, threadState
+ *   --channel <id> --name <n> --watermark <ts>   (manual, when no --from)
+ *   --type event|general         (default: inferred from name)
+ *   --commit <sha>               record the commit that carried this sync
+ */
+
+import {
+  classifyChannel,
+  fingerprintForMapping,
+  loadManifest,
+  nowIso,
+  saveManifest,
+  type ChannelState,
+  type Mapping,
+  type ThreadState,
+} from "./state-lib.ts";
+import { readFileSync } from "node:fs";
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+/** Collect repeated --slug / --event-id pairs (positional pairing by order). */
+function collectEvents(): { slug: string; eventId: number }[] {
+  const slugs: string[] = [];
+  const ids: number[] = [];
+  for (let i = 0; i < process.argv.length; i++) {
+    if (process.argv[i] === "--slug") slugs.push(process.argv[i + 1]);
+    if (process.argv[i] === "--event-id") ids.push(Number(process.argv[i + 1]));
+  }
+  return slugs.map((slug, i) => ({ slug, eventId: ids[i] }));
+}
+
+function main() {
+  const fromFile = arg("--from");
+  let channelId = arg("--channel");
+  let name = arg("--name");
+  let watermarkTs = arg("--watermark");
+  let threads: Record<string, ThreadState> = {};
+
+  if (fromFile) {
+    const payload = JSON.parse(readFileSync(fromFile, "utf8"));
+    channelId = channelId ?? payload.channel?.id;
+    name = name ?? payload.channel?.name;
+    watermarkTs = watermarkTs ?? payload._meta?.newWatermarkTs;
+    threads = payload._meta?.threadState ?? {};
+  }
+
+  if (!channelId || !name || !watermarkTs) {
+    console.error("Need --channel, --name, --watermark (or --from <fetch-output.json>)");
+    process.exit(2);
+  }
+
+  const type = (arg("--type") as "event" | "general") ?? classifyChannel(name);
+
+  // Build the mapping.
+  const kind = arg("--mapping") ?? "none";
+  let mapping: Mapping;
+  let fingerprint = "";
+  if (kind === "event") {
+    const evs = collectEvents();
+    if (!evs.length || evs.some((e) => !e.slug || !Number.isFinite(e.eventId))) {
+      console.error("--mapping event requires at least one --slug + --event-id pair");
+      process.exit(2);
+    }
+    mapping = { kind: "event", events: evs };
+    fingerprint = fingerprintForMapping(mapping);
+  } else if (kind === "skip") {
+    const reason = arg("--reason") ?? "skipped";
+    mapping = { kind: "skip", reason };
+  } else {
+    mapping = { kind: "none" };
+  }
+
+  const manifest = loadManifest();
+  const prev = manifest.channels[channelId];
+  const mergedThreads = { ...(prev?.threads ?? {}), ...threads };
+  const next: ChannelState = {
+    name,
+    type,
+    mapping,
+    watermarkTs,
+    threads: mergedThreads,
+    fingerprint: fingerprint || (kind === "event" ? prev?.fingerprint ?? "" : ""),
+    lastSyncedAt: nowIso(),
+    lastSyncedCommit: arg("--commit") ?? prev?.lastSyncedCommit ?? "",
+  };
+
+  // Avoid timestamp churn: if nothing material changed, keep the prior entry
+  // (incl. its lastSyncedAt) so a no-op re-record leaves the manifest byte-stable.
+  const material = (c?: ChannelState) =>
+    c && JSON.stringify({ n: c.name, t: c.type, m: c.mapping, w: c.watermarkTs, th: c.threads, f: c.fingerprint });
+  if (prev && material(prev) === material(next)) {
+    process.stdout.write(`no change for ${channelId} (${name})\n`);
+    return;
+  }
+  manifest.channels[channelId] = next;
+  saveManifest(manifest);
+
+  process.stdout.write(
+    JSON.stringify(
+      { channel: channelId, name, type, mapping, watermarkTs, threadCount: Object.keys(next.threads).length, fingerprint: next.fingerprint },
+      null,
+      2,
+    ) + "\n",
+  );
+}
+
+main();

--- a/.claude/skills/sync-event-from-slack/state/sync-state.json
+++ b/.claude/skills/sync-event-from-slack/state/sync-state.json
@@ -265,6 +265,24 @@
       "lastSyncedAt": "2026-06-09T01:06:45.086Z",
       "lastSyncedCommit": ""
     },
+    "C05LRKE5UCF": {
+      "name": "events-2023-september-twnz",
+      "type": "event",
+      "mapping": {
+        "kind": "event",
+        "events": [
+          {
+            "slug": "from-burnout-to-balance",
+            "eventId": 86
+          }
+        ]
+      },
+      "watermarkTs": "0",
+      "threads": {},
+      "fingerprint": "sha256:d5169b40123be1bfff3172ff6c57e167991b02a958e088f8061bbdbc586f9397",
+      "lastSyncedAt": "2026-06-09T01:45:17.341Z",
+      "lastSyncedCommit": ""
+    },
     "C05LZH9ET38": {
       "name": "events-2023-october-aut-school",
       "type": "event",
@@ -1026,12 +1044,199 @@
       "name": "event--mind-coach-april-2026",
       "type": "event",
       "mapping": {
-        "kind": "none"
+        "kind": "event",
+        "events": [
+          {
+            "slug": "she-sharp-candice-murray-own-your-energy",
+            "eventId": 87
+          }
+        ]
       },
       "watermarkTs": "1777003028.579359",
-      "threads": {},
-      "fingerprint": "",
-      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "threads": {
+        "1771485411.086039": {
+          "replyCount": 3,
+          "latestReplyTs": "1773714921.331259"
+        },
+        "1771491370.091099": {
+          "replyCount": 1,
+          "latestReplyTs": "1771492676.773499"
+        },
+        "1771545108.213559": {
+          "replyCount": 2,
+          "latestReplyTs": "1771545331.082819"
+        },
+        "1771545232.277629": {
+          "replyCount": 5,
+          "latestReplyTs": "1771558584.170759"
+        },
+        "1771566813.089589": {
+          "replyCount": 2,
+          "latestReplyTs": "1771646728.137709"
+        },
+        "1771668784.128249": {
+          "replyCount": 4,
+          "latestReplyTs": "1771670011.088369"
+        },
+        "1771918666.784439": {
+          "replyCount": 1,
+          "latestReplyTs": "1771918910.312799"
+        },
+        "1771918677.193789": {
+          "replyCount": 2,
+          "latestReplyTs": "1771986121.936219"
+        },
+        "1771918722.040229": {
+          "replyCount": 8,
+          "latestReplyTs": "1772513449.426619"
+        },
+        "1772245534.201879": {
+          "replyCount": 4,
+          "latestReplyTs": "1772520561.730659"
+        },
+        "1772245573.486769": {
+          "replyCount": 13,
+          "latestReplyTs": "1772741809.392859"
+        },
+        "1772531894.488519": {
+          "replyCount": 5,
+          "latestReplyTs": "1772572150.997999"
+        },
+        "1772658727.082229": {
+          "replyCount": 2,
+          "latestReplyTs": "1772935389.592179"
+        },
+        "1772671146.372529": {
+          "replyCount": 2,
+          "latestReplyTs": "1772696133.053419"
+        },
+        "1773007742.526129": {
+          "replyCount": 7,
+          "latestReplyTs": "1774949049.571689"
+        },
+        "1773007836.916429": {
+          "replyCount": 4,
+          "latestReplyTs": "1773176611.302309"
+        },
+        "1773204369.871729": {
+          "replyCount": 2,
+          "latestReplyTs": "1773456037.202099"
+        },
+        "1773544341.194559": {
+          "replyCount": 8,
+          "latestReplyTs": "1773644941.230879"
+        },
+        "1773712069.790989": {
+          "replyCount": 4,
+          "latestReplyTs": "1773732405.910179"
+        },
+        "1773714793.405759": {
+          "replyCount": 32,
+          "latestReplyTs": "1773803394.324279"
+        },
+        "1773724476.086649": {
+          "replyCount": 1,
+          "latestReplyTs": "1773724554.148639"
+        },
+        "1773736633.297899": {
+          "replyCount": 13,
+          "latestReplyTs": "1773809267.881549"
+        },
+        "1773803625.603529": {
+          "replyCount": 16,
+          "latestReplyTs": "1773955830.093029"
+        },
+        "1773995516.171689": {
+          "replyCount": 10,
+          "latestReplyTs": "1774052367.044289"
+        },
+        "1774507036.452419": {
+          "replyCount": 12,
+          "latestReplyTs": "1775034657.180919"
+        },
+        "1774509168.483929": {
+          "replyCount": 3,
+          "latestReplyTs": "1774949116.349519"
+        },
+        "1774782557.038669": {
+          "replyCount": 5,
+          "latestReplyTs": "1774835928.045579"
+        },
+        "1775255842.061129": {
+          "replyCount": 3,
+          "latestReplyTs": "1775259509.759729"
+        },
+        "1775448484.122609": {
+          "replyCount": 3,
+          "latestReplyTs": "1775449012.352519"
+        },
+        "1775543749.072209": {
+          "replyCount": 1,
+          "latestReplyTs": "1775783334.238919"
+        },
+        "1775694234.605979": {
+          "replyCount": 20,
+          "latestReplyTs": "1775865076.822589"
+        },
+        "1775760632.450649": {
+          "replyCount": 2,
+          "latestReplyTs": "1775804546.836349"
+        },
+        "1775777871.496089": {
+          "replyCount": 1,
+          "latestReplyTs": "1776025046.014019"
+        },
+        "1775987069.629419": {
+          "replyCount": 35,
+          "latestReplyTs": "1776214831.995359"
+        },
+        "1776068529.958559": {
+          "replyCount": 1,
+          "latestReplyTs": "1776070973.672059"
+        },
+        "1776068674.001419": {
+          "replyCount": 1,
+          "latestReplyTs": "1776068707.282429"
+        },
+        "1776115230.801839": {
+          "replyCount": 2,
+          "latestReplyTs": "1776116116.321959"
+        },
+        "1776216215.878269": {
+          "replyCount": 1,
+          "latestReplyTs": "1776277420.136219"
+        },
+        "1776221313.109099": {
+          "replyCount": 1,
+          "latestReplyTs": "1776222803.233849"
+        },
+        "1776238149.126309": {
+          "replyCount": 1,
+          "latestReplyTs": "1776238579.077909"
+        },
+        "1776238165.146599": {
+          "replyCount": 2,
+          "latestReplyTs": "1776239593.368329"
+        },
+        "1776238284.378559": {
+          "replyCount": 1,
+          "latestReplyTs": "1776238534.492629"
+        },
+        "1776246886.489339": {
+          "replyCount": 5,
+          "latestReplyTs": "1776277384.387819"
+        },
+        "1776673347.235589": {
+          "replyCount": 3,
+          "latestReplyTs": "1776678916.236419"
+        },
+        "1776759576.568029": {
+          "replyCount": 4,
+          "latestReplyTs": "1776921258.707979"
+        }
+      },
+      "fingerprint": "sha256:f22eb4a17e71a9a52d0507d54819409ce71072125e95414cd37a242e41281a97",
+      "lastSyncedAt": "2026-06-09T01:45:13.080Z",
       "lastSyncedCommit": ""
     },
     "C0AFVNS9FEW": {

--- a/.claude/skills/sync-event-from-slack/state/sync-state.json
+++ b/.claude/skills/sync-event-from-slack/state/sync-state.json
@@ -1,0 +1,1831 @@
+{
+  "version": 1,
+  "channels": {
+    "C01BAQ6ADQF": {
+      "name": "recruitment",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555703.673489",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C01DSD0HCQK": {
+      "name": "monthly-newsletter",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1780219214.503249",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C01NEKYP0CR": {
+      "name": "t-shirts",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555705.572599",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C01SU11D0G7": {
+      "name": "expo-2021-motat",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555706.583559",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C01UFNYKAGH": {
+      "name": "awards-opportunities",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555707.556409",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C020K43PBLL": {
+      "name": "events-2021-techweek-imaginezone",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555708.556449",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C025NC3QWDQ": {
+      "name": "events-2021-girl-guiding",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555709.517109",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C026C5R2QQK": {
+      "name": "expo-2021-northwest-schools",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555710.521179",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C033KNWMTGD": {
+      "name": "podcast",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555711.490919",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C0342CMEV7B": {
+      "name": "design-brand",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555712.446479",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C03J6C08WQL": {
+      "name": "team-leaves",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1780866680.849279",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C03KYCN4Z6C": {
+      "name": "expo-2022-tech22",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555714.364369",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C0438BZ7DL6": {
+      "name": "gifts",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1780559027.001549",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C0476MCR9B2": {
+      "name": "expo-2022-motat",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555716.285009",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C04P6N2SZ0D": {
+      "name": "event-ambassadors",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555717.226889",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C04PN9L7UG1": {
+      "name": "new-ambassadors-2023",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555718.197049",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C051VLT4TT2": {
+      "name": "events-planning",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555719.170639",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C052DTYUVUZ": {
+      "name": "event-techweek-otahuhucollege",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555720.113049",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C053P3ZRU64": {
+      "name": "twnz-june-21-tbc",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555721.086149",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C058E3Q065S": {
+      "name": "web-revamp-content",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555722.150819",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C05DM7PRWM7": {
+      "name": "mentorships",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1780862418.898089",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C05KPDDFT9D": {
+      "name": "website-team",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1780274274.022849",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C05LZH9ET38": {
+      "name": "events-2023-october-aut-school",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555725.120439",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C05MVTQ59BJ": {
+      "name": "events-2023-google-educator-november",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555726.122139",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C05PDCPJD1N": {
+      "name": "socialmedia",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555727.098769",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C05S10ENU4U": {
+      "name": "school-and-google-events-committee",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555728.028599",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C064QA7SQAV": {
+      "name": "events-2024-feb-fiserv-hasini",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555728.996989",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C06L3HKCRD5": {
+      "name": "pr-june-digital-boost-event-shesharp-intro",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555729.960279",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C06NMR161AS": {
+      "name": "events-2024-july-fisherandpaykel-aihackathon",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555730.933779",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C06NRB1Q8KF": {
+      "name": "gridakl-sharedoffice-for-shesharp",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555731.901809",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C06Q986DV": {
+      "name": "random",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555693.918789",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.085Z",
+      "lastSyncedCommit": ""
+    },
+    "C06Q9FJNR": {
+      "name": "general",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1780924736.060429",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C06QBKPK8": {
+      "name": "team-meetings",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1780840048.907059",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C0743UGNNMU": {
+      "name": "startupweekend-auckland",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555732.846049",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C075ANENL59": {
+      "name": "security-awards-2024",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555733.806359",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C076RJ2LHEC": {
+      "name": "events-2024-august-fonterra",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555734.924089",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C077TLWSVE0": {
+      "name": "event-2024-august-aihackthon-academyex",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555735.865789",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C07FKTCU98X": {
+      "name": "announcements",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555736.909559",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C07G4CN070U": {
+      "name": "events-2024-november-google",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555737.884229",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C07G55Q0P1A": {
+      "name": "events-october-10th-anniversary",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555738.836449",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C07K2J47C48": {
+      "name": "events-2024-november-hcl",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555739.776799",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C07KH9HM2PP": {
+      "name": "events-2024-sep--summeroftech",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555740.754689",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C07MX2A9LKA": {
+      "name": "catering-10thanniv-and-google",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555741.834869",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C083VSX5W": {
+      "name": "website-admin",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555696.901349",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C08EEQC49RD": {
+      "name": "event-iwd-march-2025",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555742.937039",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C08GDT7CW23": {
+      "name": "event-myob-techwerk-may-2025",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555743.912699",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C08GMGCQHQA": {
+      "name": "event-iamremarkable-april-2025",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555744.926479",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C08GULKDVBM": {
+      "name": "event-myob-may-2025",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555746.328899",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C08UXMZTDC0": {
+      "name": "event-ethnic-conference-june-2025",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555747.336369",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C092BSZGPJB": {
+      "name": "event-xero-oct-2025",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555748.359119",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C092LHWGLG6": {
+      "name": "event-hcltech-nov21-2025",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555749.230179",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C092QQP6JQL": {
+      "name": "event-fonterra-sept-2025",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555750.232799",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C092YTH4B6V": {
+      "name": "event-techbabes-industry-july-2025",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555751.195599",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C093EN4FF9N": {
+      "name": "event-ai-forum-hackathon-aug-2025",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1780924736.203079",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C0959LH63QQ": {
+      "name": "funding-applications",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1780866105.771489",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C096M3GC3BL": {
+      "name": "event-vector-nov12-2025",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555754.321859",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C098CCM2F2T": {
+      "name": "she-sharp-policies",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555755.372069",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C0ACA3MV0R4": {
+      "name": "people",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1779859197.046229",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C0ADRAGNTTQ": {
+      "name": "event-academyex-iwd2026-6march-2026",
+      "type": "event",
+      "mapping": {
+        "kind": "event",
+        "events": [
+          {
+            "slug": "she-sharp-and-academyex-international-womens-day-2026",
+            "eventId": 85
+          }
+        ]
+      },
+      "watermarkTs": "1773305096.205889",
+      "threads": {
+        "1770802912.391369": {
+          "replyCount": 1,
+          "latestReplyTs": "1770806341.722929"
+        },
+        "1770858772.715509": {
+          "replyCount": 4,
+          "latestReplyTs": "1770890605.551829"
+        },
+        "1770885289.354019": {
+          "replyCount": 3,
+          "latestReplyTs": "1770888758.686749"
+        },
+        "1770895038.479979": {
+          "replyCount": 1,
+          "latestReplyTs": "1770913646.353079"
+        },
+        "1770923211.807689": {
+          "replyCount": 1,
+          "latestReplyTs": "1770924585.600909"
+        },
+        "1770923403.698189": {
+          "replyCount": 5,
+          "latestReplyTs": "1770942039.503719"
+        },
+        "1770951016.536869": {
+          "replyCount": 3,
+          "latestReplyTs": "1770971935.615689"
+        },
+        "1770952273.320639": {
+          "replyCount": 13,
+          "latestReplyTs": "1771037749.765079"
+        },
+        "1770953876.903089": {
+          "replyCount": 2,
+          "latestReplyTs": "1770963631.300259"
+        },
+        "1770963782.858539": {
+          "replyCount": 1,
+          "latestReplyTs": "1770965091.252299"
+        },
+        "1770966525.023069": {
+          "replyCount": 11,
+          "latestReplyTs": "1770973026.392129"
+        },
+        "1771233828.251159": {
+          "replyCount": 1,
+          "latestReplyTs": "1771297316.928949"
+        },
+        "1771234935.437199": {
+          "replyCount": 1,
+          "latestReplyTs": "1771297011.498319"
+        },
+        "1771319131.734249": {
+          "replyCount": 22,
+          "latestReplyTs": "1772442944.384239"
+        },
+        "1771390776.716279": {
+          "replyCount": 21,
+          "latestReplyTs": "1771562309.490409"
+        },
+        "1771470137.179469": {
+          "replyCount": 3,
+          "latestReplyTs": "1771480473.809229"
+        },
+        "1771481611.485089": {
+          "replyCount": 2,
+          "latestReplyTs": "1771482187.708839"
+        },
+        "1771482300.984769": {
+          "replyCount": 5,
+          "latestReplyTs": "1771551789.169749"
+        },
+        "1771541178.998969": {
+          "replyCount": 1,
+          "latestReplyTs": "1771541245.764279"
+        },
+        "1771541468.645889": {
+          "replyCount": 3,
+          "latestReplyTs": "1771543182.808329"
+        },
+        "1771541698.190869": {
+          "replyCount": 1,
+          "latestReplyTs": "1771541738.090319"
+        },
+        "1771552322.085589": {
+          "replyCount": 3,
+          "latestReplyTs": "1771666515.505229"
+        },
+        "1771562018.569849": {
+          "replyCount": 1,
+          "latestReplyTs": "1771569433.010099"
+        },
+        "1771562131.961389": {
+          "replyCount": 2,
+          "latestReplyTs": "1771566867.632429"
+        },
+        "1771733550.280549": {
+          "replyCount": 1,
+          "latestReplyTs": "1771735170.036479"
+        },
+        "1771733571.216469": {
+          "replyCount": 1,
+          "latestReplyTs": "1771736670.597659"
+        },
+        "1771808100.792069": {
+          "replyCount": 13,
+          "latestReplyTs": "1771922489.819389"
+        },
+        "1771810278.069389": {
+          "replyCount": 13,
+          "latestReplyTs": "1771918823.506189"
+        },
+        "1771836680.157449": {
+          "replyCount": 1,
+          "latestReplyTs": "1771870240.080869"
+        },
+        "1771898675.353949": {
+          "replyCount": 3,
+          "latestReplyTs": "1772065129.645209"
+        },
+        "1771902626.334989": {
+          "replyCount": 5,
+          "latestReplyTs": "1771905419.621089"
+        },
+        "1771914495.231939": {
+          "replyCount": 5,
+          "latestReplyTs": "1771916531.061059"
+        },
+        "1771922979.356349": {
+          "replyCount": 2,
+          "latestReplyTs": "1771924551.574589"
+        },
+        "1771990801.414899": {
+          "replyCount": 2,
+          "latestReplyTs": "1771992578.952679"
+        },
+        "1772041680.094209": {
+          "replyCount": 2,
+          "latestReplyTs": "1772043118.542339"
+        },
+        "1772049797.534839": {
+          "replyCount": 6,
+          "latestReplyTs": "1772050400.050999"
+        },
+        "1772067886.667479": {
+          "replyCount": 2,
+          "latestReplyTs": "1772404758.649209"
+        },
+        "1772068038.430849": {
+          "replyCount": 13,
+          "latestReplyTs": "1772092308.679989"
+        },
+        "1772069970.626189": {
+          "replyCount": 3,
+          "latestReplyTs": "1772070027.882269"
+        },
+        "1772091617.355749": {
+          "replyCount": 2,
+          "latestReplyTs": "1772092158.182789"
+        },
+        "1772320863.476169": {
+          "replyCount": 1,
+          "latestReplyTs": "1772443825.182269"
+        },
+        "1772360483.874039": {
+          "replyCount": 14,
+          "latestReplyTs": "1772530667.341289"
+        },
+        "1772394077.337549": {
+          "replyCount": 9,
+          "latestReplyTs": "1772404312.736109"
+        },
+        "1772406399.111919": {
+          "replyCount": 1,
+          "latestReplyTs": "1772496840.012369"
+        },
+        "1772431486.563589": {
+          "replyCount": 30,
+          "latestReplyTs": "1772708400.340269"
+        },
+        "1772435357.815889": {
+          "replyCount": 1,
+          "latestReplyTs": "1773047067.105899"
+        },
+        "1772444413.133369": {
+          "replyCount": 14,
+          "latestReplyTs": "1772573542.114169"
+        },
+        "1772490278.493959": {
+          "replyCount": 2,
+          "latestReplyTs": "1772490493.677579"
+        },
+        "1772498020.256439": {
+          "replyCount": 1,
+          "latestReplyTs": "1772500726.842899"
+        },
+        "1772569259.617879": {
+          "replyCount": 4,
+          "latestReplyTs": "1772589988.431789"
+        },
+        "1772582755.665569": {
+          "replyCount": 3,
+          "latestReplyTs": "1772582893.868699"
+        },
+        "1772608491.420389": {
+          "replyCount": 4,
+          "latestReplyTs": "1772668369.440279"
+        },
+        "1772657973.220499": {
+          "replyCount": 9,
+          "latestReplyTs": "1772686462.779939"
+        },
+        "1772662560.130209": {
+          "replyCount": 9,
+          "latestReplyTs": "1772705922.930179"
+        },
+        "1772662901.743029": {
+          "replyCount": 7,
+          "latestReplyTs": "1772686391.654179"
+        },
+        "1772740921.993229": {
+          "replyCount": 2,
+          "latestReplyTs": "1772743255.104369"
+        },
+        "1772884905.369649": {
+          "replyCount": 6,
+          "latestReplyTs": "1772924980.453889"
+        },
+        "1772933607.405409": {
+          "replyCount": 2,
+          "latestReplyTs": "1772944172.094069"
+        }
+      },
+      "fingerprint": "sha256:81501051a00fec7bf479aa4617f3d4e862736e73424b4cbaff457da017989dd6",
+      "lastSyncedAt": "2026-06-09T01:01:18.088Z",
+      "lastSyncedCommit": ""
+    },
+    "C0ADWT94QTX": {
+      "name": "ambassador-and-volunteer-application",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555757.351769",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C0AERNZ1GKH": {
+      "name": "event-msd-series-2026",
+      "type": "event",
+      "mapping": {
+        "kind": "skip",
+        "reason": "umbrella planning channel; the 4 monthly her-waka events are synced from their own event-msd-* channels"
+      },
+      "watermarkTs": "1777003016.597469",
+      "threads": {
+        "1771485835.991949": {
+          "replyCount": 2,
+          "latestReplyTs": "1771562407.338569"
+        },
+        "1771553308.779239": {
+          "replyCount": 6,
+          "latestReplyTs": "1771709331.256829"
+        },
+        "1771832229.875289": {
+          "replyCount": 1,
+          "latestReplyTs": "1771832266.798879"
+        },
+        "1771834608.338249": {
+          "replyCount": 2,
+          "latestReplyTs": "1771982569.509759"
+        },
+        "1772095058.284139": {
+          "replyCount": 6,
+          "latestReplyTs": "1772257659.601909"
+        },
+        "1772442005.820669": {
+          "replyCount": 2,
+          "latestReplyTs": "1772442308.486479"
+        },
+        "1772478297.628199": {
+          "replyCount": 4,
+          "latestReplyTs": "1772523541.583709"
+        },
+        "1773107667.241589": {
+          "replyCount": 1,
+          "latestReplyTs": "1773194148.222939"
+        },
+        "1773732246.296349": {
+          "replyCount": 1,
+          "latestReplyTs": "1773792287.020819"
+        }
+      },
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:04:39.947Z",
+      "lastSyncedCommit": ""
+    },
+    "C0AFFS33FRR": {
+      "name": "msd-proposal",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555758.311579",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C0AFP8Q9T7D": {
+      "name": "event--mind-coach-april-2026",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777003028.579359",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C0AFVNS9FEW": {
+      "name": "event-msd-march-2026",
+      "type": "event",
+      "mapping": {
+        "kind": "event",
+        "events": [
+          {
+            "slug": "her-waka",
+            "eventId": 88
+          }
+        ]
+      },
+      "watermarkTs": "1777003052.899939",
+      "threads": {
+        "1771560819.539109": {
+          "replyCount": 2,
+          "latestReplyTs": "1771561910.580539"
+        },
+        "1771561857.466479": {
+          "replyCount": 1,
+          "latestReplyTs": "1771561983.966569"
+        },
+        "1772177978.710129": {
+          "replyCount": 3,
+          "latestReplyTs": "1772438652.138699"
+        },
+        "1772227053.464039": {
+          "replyCount": 3,
+          "latestReplyTs": "1772348958.525089"
+        },
+        "1772439533.653349": {
+          "replyCount": 6,
+          "latestReplyTs": "1773035524.296439"
+        },
+        "1772441013.960519": {
+          "replyCount": 1,
+          "latestReplyTs": "1772441184.758729"
+        },
+        "1772477016.823549": {
+          "replyCount": 2,
+          "latestReplyTs": "1772521954.040419"
+        },
+        "1772524876.023619": {
+          "replyCount": 4,
+          "latestReplyTs": "1773035214.196599"
+        },
+        "1772604292.154949": {
+          "replyCount": 2,
+          "latestReplyTs": "1772762211.677369"
+        },
+        "1773041543.499849": {
+          "replyCount": 1,
+          "latestReplyTs": "1773041635.851189"
+        },
+        "1773050233.470869": {
+          "replyCount": 1,
+          "latestReplyTs": "1773055728.653909"
+        },
+        "1773168410.436359": {
+          "replyCount": 1,
+          "latestReplyTs": "1773208869.083599"
+        },
+        "1773312371.303459": {
+          "replyCount": 1,
+          "latestReplyTs": "1773340710.194699"
+        },
+        "1773389660.192199": {
+          "replyCount": 1,
+          "latestReplyTs": "1773396149.824519"
+        },
+        "1773393206.142309": {
+          "replyCount": 1,
+          "latestReplyTs": "1773396178.097869"
+        },
+        "1773426604.636949": {
+          "replyCount": 4,
+          "latestReplyTs": "1773478941.248759"
+        },
+        "1773648393.678319": {
+          "replyCount": 3,
+          "latestReplyTs": "1773814725.828919"
+        },
+        "1773714219.199949": {
+          "replyCount": 7,
+          "latestReplyTs": "1773732212.084509"
+        },
+        "1773815017.232259": {
+          "replyCount": 9,
+          "latestReplyTs": "1773819632.702709"
+        },
+        "1773903662.995899": {
+          "replyCount": 2,
+          "latestReplyTs": "1773966074.018179"
+        },
+        "1773986591.018619": {
+          "replyCount": 3,
+          "latestReplyTs": "1774062599.303959"
+        },
+        "1773997306.049579": {
+          "replyCount": 3,
+          "latestReplyTs": "1774152199.832869"
+        },
+        "1774294988.791139": {
+          "replyCount": 4,
+          "latestReplyTs": "1774332314.271849"
+        },
+        "1774317381.369449": {
+          "replyCount": 1,
+          "latestReplyTs": "1774335582.089799"
+        },
+        "1774320300.837249": {
+          "replyCount": 1,
+          "latestReplyTs": "1774323055.044299"
+        },
+        "1774321464.476379": {
+          "replyCount": 1,
+          "latestReplyTs": "1774323044.098419"
+        },
+        "1774322541.861379": {
+          "replyCount": 4,
+          "latestReplyTs": "1774324278.687359"
+        },
+        "1774323140.006319": {
+          "replyCount": 3,
+          "latestReplyTs": "1774328394.211599"
+        },
+        "1774330787.945999": {
+          "replyCount": 3,
+          "latestReplyTs": "1774337203.954189"
+        },
+        "1774336363.623409": {
+          "replyCount": 7,
+          "latestReplyTs": "1774343286.910369"
+        },
+        "1774415489.994669": {
+          "replyCount": 8,
+          "latestReplyTs": "1774508681.220119"
+        },
+        "1774430215.906659": {
+          "replyCount": 1,
+          "latestReplyTs": "1774493877.064439"
+        }
+      },
+      "fingerprint": "sha256:cfacdffd15546fe05252d02aa5ef78bd53120e392585ade87ecfb110d18a10c9",
+      "lastSyncedAt": "2026-06-09T01:02:38.619Z",
+      "lastSyncedCommit": ""
+    },
+    "C0AFX3C4H5Z": {
+      "name": "event-msd-may5-2026",
+      "type": "event",
+      "mapping": {
+        "kind": "event",
+        "events": [
+          {
+            "slug": "her-waka-may-2026",
+            "eventId": 90
+          }
+        ]
+      },
+      "watermarkTs": "1779780032.232479",
+      "threads": {
+        "1775205252.793959": {
+          "replyCount": 6,
+          "latestReplyTs": "1775518015.318079"
+        },
+        "1775205383.871309": {
+          "replyCount": 1,
+          "latestReplyTs": "1775463582.552149"
+        },
+        "1775545753.642589": {
+          "replyCount": 2,
+          "latestReplyTs": "1775760236.781859"
+        },
+        "1775545920.862199": {
+          "replyCount": 1,
+          "latestReplyTs": "1777881517.115379"
+        },
+        "1775556412.777789": {
+          "replyCount": 4,
+          "latestReplyTs": "1775622723.553089"
+        },
+        "1776931882.550009": {
+          "replyCount": 1,
+          "latestReplyTs": "1776935965.995299"
+        },
+        "1777101261.825189": {
+          "replyCount": 3,
+          "latestReplyTs": "1777242910.027299"
+        },
+        "1777356272.008239": {
+          "replyCount": 5,
+          "latestReplyTs": "1777802182.866699"
+        },
+        "1777357148.483999": {
+          "replyCount": 6,
+          "latestReplyTs": "1777365179.086279"
+        },
+        "1777494327.809179": {
+          "replyCount": 1,
+          "latestReplyTs": "1777497434.693389"
+        },
+        "1777615964.891169": {
+          "replyCount": 1,
+          "latestReplyTs": "1777682971.012749"
+        },
+        "1777802238.140469": {
+          "replyCount": 3,
+          "latestReplyTs": "1777877163.506209"
+        },
+        "1777851399.093719": {
+          "replyCount": 6,
+          "latestReplyTs": "1777880015.922369"
+        },
+        "1777883360.527559": {
+          "replyCount": 1,
+          "latestReplyTs": "1777888243.092839"
+        },
+        "1777883771.069549": {
+          "replyCount": 1,
+          "latestReplyTs": "1777887837.209509"
+        },
+        "1778921699.489359": {
+          "replyCount": 1,
+          "latestReplyTs": "1778967265.229669"
+        }
+      },
+      "fingerprint": "sha256:8c59bdedb78295ed9aa11565a91afaae7f319b47b7f4c9826adede94d4ef7e15",
+      "lastSyncedAt": "2026-06-09T01:03:23.528Z",
+      "lastSyncedCommit": ""
+    },
+    "C0AFZAW474L": {
+      "name": "event-security-xero-october-2026",
+      "type": "event",
+      "mapping": {
+        "kind": "skip",
+        "reason": "insufficient data (only a date-poll message, no confirmed date/speaker/poster)"
+      },
+      "watermarkTs": "1777003085.752199",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:04:57.000Z",
+      "lastSyncedCommit": ""
+    },
+    "C0AG1BM4UMU": {
+      "name": "event-msd-april7--2026",
+      "type": "event",
+      "mapping": {
+        "kind": "event",
+        "events": [
+          {
+            "slug": "her-waka-april-2026",
+            "eventId": 89
+          }
+        ]
+      },
+      "watermarkTs": "1777003062.810939",
+      "threads": {
+        "1773209127.142309": {
+          "replyCount": 3,
+          "latestReplyTs": "1773212895.752619"
+        },
+        "1773776818.690179": {
+          "replyCount": 1,
+          "latestReplyTs": "1773790056.177569"
+        },
+        "1773815860.826359": {
+          "replyCount": 8,
+          "latestReplyTs": "1774228004.130539"
+        },
+        "1774512833.173639": {
+          "replyCount": 6,
+          "latestReplyTs": "1774735818.751149"
+        },
+        "1774517303.968159": {
+          "replyCount": 2,
+          "latestReplyTs": "1774559604.837189"
+        },
+        "1774637811.024419": {
+          "replyCount": 3,
+          "latestReplyTs": "1774647333.953929"
+        },
+        "1774676278.263309": {
+          "replyCount": 1,
+          "latestReplyTs": "1774677652.934819"
+        },
+        "1775202401.468139": {
+          "replyCount": 6,
+          "latestReplyTs": "1775273281.347939"
+        },
+        "1775284952.916389": {
+          "replyCount": 2,
+          "latestReplyTs": "1775448912.726179"
+        },
+        "1775326277.979789": {
+          "replyCount": 1,
+          "latestReplyTs": "1775426905.325529"
+        },
+        "1775456771.936869": {
+          "replyCount": 5,
+          "latestReplyTs": "1775550518.079609"
+        },
+        "1775559334.960489": {
+          "replyCount": 4,
+          "latestReplyTs": "1775639444.012529"
+        },
+        "1775643609.533659": {
+          "replyCount": 1,
+          "latestReplyTs": "1775724962.714239"
+        },
+        "1775684965.522279": {
+          "replyCount": 3,
+          "latestReplyTs": "1775793277.387929"
+        }
+      },
+      "fingerprint": "sha256:23e7954ddefb145350642bdd7cf5196d6ae1e2784a2a331f60d53229f4b52b99",
+      "lastSyncedAt": "2026-06-09T01:03:00.524Z",
+      "lastSyncedCommit": ""
+    },
+    "C0AGGCHG2E5": {
+      "name": "event-msd-june2-2026",
+      "type": "event",
+      "mapping": {
+        "kind": "event",
+        "events": [
+          {
+            "slug": "her-waka-june-2026",
+            "eventId": 92
+          }
+        ]
+      },
+      "watermarkTs": "1780827125.561969",
+      "threads": {
+        "1772435914.741019": {
+          "replyCount": 8,
+          "latestReplyTs": "1772439459.131219"
+        },
+        "1773722069.734599": {
+          "replyCount": 5,
+          "latestReplyTs": "1774301480.335739"
+        },
+        "1776844564.149659": {
+          "replyCount": 3,
+          "latestReplyTs": "1776932389.689649"
+        },
+        "1776847764.876049": {
+          "replyCount": 3,
+          "latestReplyTs": "1777020969.588849"
+        },
+        "1776984678.519179": {
+          "replyCount": 11,
+          "latestReplyTs": "1777756508.272539"
+        },
+        "1777536410.819339": {
+          "replyCount": 2,
+          "latestReplyTs": "1777574702.482269"
+        },
+        "1778055606.125859": {
+          "replyCount": 16,
+          "latestReplyTs": "1779303720.593039"
+        },
+        "1779771481.636889": {
+          "replyCount": 2,
+          "latestReplyTs": "1779780298.968629"
+        },
+        "1779860198.863559": {
+          "replyCount": 3,
+          "latestReplyTs": "1779868327.376429"
+        },
+        "1780025594.700179": {
+          "replyCount": 4,
+          "latestReplyTs": "1780112674.285849"
+        },
+        "1780119292.199919": {
+          "replyCount": 1,
+          "latestReplyTs": "1780122521.906129"
+        },
+        "1780827125.561969": {
+          "replyCount": 1,
+          "latestReplyTs": "1780858492.643809"
+        }
+      },
+      "fingerprint": "sha256:7dfce04f58c7ff901430c9bf5bd0b2ff0ecef000220d990205494286717bc818",
+      "lastSyncedAt": "2026-06-09T01:03:44.587Z",
+      "lastSyncedCommit": ""
+    },
+    "C0AGVRL0G5A": {
+      "name": "contact-form-notifications",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555759.275749",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C0AQS8K2FQQ": {
+      "name": "event-peyvand-academy-13june-and-20june",
+      "type": "event",
+      "mapping": {
+        "kind": "event",
+        "events": [
+          {
+            "slug": "peyvand-academy-13-june-2026",
+            "eventId": 93
+          },
+          {
+            "slug": "peyvand-academy-20-june-2026",
+            "eventId": 94
+          }
+        ]
+      },
+      "watermarkTs": "1780964820.674639",
+      "threads": {
+        "1774947805.203089": {
+          "replyCount": 3,
+          "latestReplyTs": "1774947949.360279"
+        },
+        "1777430630.488599": {
+          "replyCount": 3,
+          "latestReplyTs": "1777525587.040119"
+        },
+        "1777578629.693419": {
+          "replyCount": 26,
+          "latestReplyTs": "1778488845.086719"
+        },
+        "1777584692.654029": {
+          "replyCount": 1,
+          "latestReplyTs": "1777584976.000529"
+        }
+      },
+      "fingerprint": "sha256:bfefac7f3c9156ec3681b91839a1bbdf805add2ebda875fe9c4b78b39abd878a",
+      "lastSyncedAt": "2026-06-09T01:04:19.973Z",
+      "lastSyncedCommit": ""
+    },
+    "C0AS0KW8KQX": {
+      "name": "event-aut-linkedin-15-may-2026",
+      "type": "event",
+      "mapping": {
+        "kind": "event",
+        "events": [
+          {
+            "slug": "making-linkedin-work-for-you-with-stuart-little",
+            "eventId": 91
+          }
+        ]
+      },
+      "watermarkTs": "1779428054.318289",
+      "threads": {
+        "1776070391.702869": {
+          "replyCount": 1,
+          "latestReplyTs": "1776070426.053799"
+        },
+        "1776239880.109219": {
+          "replyCount": 1,
+          "latestReplyTs": "1776241918.680709"
+        },
+        "1776243998.201329": {
+          "replyCount": 5,
+          "latestReplyTs": "1776301164.267739"
+        },
+        "1776673830.045039": {
+          "replyCount": 2,
+          "latestReplyTs": "1776675673.212799"
+        },
+        "1776728910.766859": {
+          "replyCount": 4,
+          "latestReplyTs": "1776742207.762539"
+        },
+        "1776729570.161889": {
+          "replyCount": 3,
+          "latestReplyTs": "1776733792.570019"
+        },
+        "1776747026.940259": {
+          "replyCount": 2,
+          "latestReplyTs": "1776752128.215479"
+        },
+        "1776795827.703399": {
+          "replyCount": 3,
+          "latestReplyTs": "1776819598.612029"
+        },
+        "1776832797.181209": {
+          "replyCount": 10,
+          "latestReplyTs": "1776871084.018219"
+        },
+        "1776841076.890799": {
+          "replyCount": 5,
+          "latestReplyTs": "1776849506.943239"
+        },
+        "1776852168.681359": {
+          "replyCount": 4,
+          "latestReplyTs": "1776883468.058809"
+        },
+        "1776865647.944489": {
+          "replyCount": 3,
+          "latestReplyTs": "1776938886.112139"
+        },
+        "1776865848.002149": {
+          "replyCount": 9,
+          "latestReplyTs": "1777021583.236659"
+        },
+        "1777016063.241229": {
+          "replyCount": 16,
+          "latestReplyTs": "1777083041.735039"
+        },
+        "1777020189.072409": {
+          "replyCount": 2,
+          "latestReplyTs": "1777020635.433869"
+        },
+        "1777020730.885399": {
+          "replyCount": 2,
+          "latestReplyTs": "1777517552.924789"
+        },
+        "1777068885.895279": {
+          "replyCount": 2,
+          "latestReplyTs": "1777082363.480859"
+        },
+        "1777401751.473289": {
+          "replyCount": 1,
+          "latestReplyTs": "1777403843.242359"
+        },
+        "1777536028.927039": {
+          "replyCount": 3,
+          "latestReplyTs": "1777538335.786979"
+        },
+        "1777620480.769019": {
+          "replyCount": 2,
+          "latestReplyTs": "1777621013.389989"
+        },
+        "1777849244.767939": {
+          "replyCount": 4,
+          "latestReplyTs": "1777850179.995819"
+        },
+        "1777868184.593419": {
+          "replyCount": 1,
+          "latestReplyTs": "1777869988.435129"
+        },
+        "1777883893.741519": {
+          "replyCount": 4,
+          "latestReplyTs": "1777949610.411469"
+        },
+        "1777884452.268369": {
+          "replyCount": 4,
+          "latestReplyTs": "1778487066.194029"
+        },
+        "1777934551.836859": {
+          "replyCount": 2,
+          "latestReplyTs": "1777935633.328539"
+        },
+        "1778053546.884649": {
+          "replyCount": 6,
+          "latestReplyTs": "1778055897.514119"
+        },
+        "1778199590.840949": {
+          "replyCount": 3,
+          "latestReplyTs": "1778299108.468659"
+        },
+        "1778419822.214859": {
+          "replyCount": 23,
+          "latestReplyTs": "1778759470.469629"
+        },
+        "1778468876.643389": {
+          "replyCount": 3,
+          "latestReplyTs": "1778545133.155759"
+        },
+        "1778496295.002169": {
+          "replyCount": 1,
+          "latestReplyTs": "1778547605.783629"
+        },
+        "1778548095.528139": {
+          "replyCount": 6,
+          "latestReplyTs": "1778548895.436869"
+        },
+        "1778548993.470659": {
+          "replyCount": 4,
+          "latestReplyTs": "1778670491.878359"
+        },
+        "1778570158.024829": {
+          "replyCount": 1,
+          "latestReplyTs": "1778571105.706469"
+        },
+        "1778576862.546019": {
+          "replyCount": 3,
+          "latestReplyTs": "1778612556.345759"
+        },
+        "1778576983.021339": {
+          "replyCount": 10,
+          "latestReplyTs": "1778714811.498369"
+        },
+        "1778578684.520299": {
+          "replyCount": 1,
+          "latestReplyTs": "1778578878.141199"
+        },
+        "1778613043.246489": {
+          "replyCount": 5,
+          "latestReplyTs": "1778619478.418339"
+        },
+        "1778655744.230619": {
+          "replyCount": 2,
+          "latestReplyTs": "1778655875.835519"
+        },
+        "1778667244.223429": {
+          "replyCount": 1,
+          "latestReplyTs": "1778696265.030829"
+        },
+        "1778725230.430889": {
+          "replyCount": 3,
+          "latestReplyTs": "1778734807.796759"
+        },
+        "1778823149.145029": {
+          "replyCount": 2,
+          "latestReplyTs": "1778827242.156589"
+        },
+        "1778832885.941149": {
+          "replyCount": 2,
+          "latestReplyTs": "1779670928.300709"
+        },
+        "1778835269.506499": {
+          "replyCount": 1,
+          "latestReplyTs": "1778835325.884229"
+        },
+        "1778837189.692379": {
+          "replyCount": 4,
+          "latestReplyTs": "1778896012.318039"
+        },
+        "1779055030.403679": {
+          "replyCount": 2,
+          "latestReplyTs": "1779093748.682059"
+        },
+        "1779055159.683989": {
+          "replyCount": 2,
+          "latestReplyTs": "1779055470.629609"
+        },
+        "1779426476.794069": {
+          "replyCount": 2,
+          "latestReplyTs": "1779428054.318289"
+        }
+      },
+      "fingerprint": "sha256:be2036a02ed98ffc71e9651688a99632a81ddc63d9aeed2f3f06f65695f24a33",
+      "lastSyncedAt": "2026-06-09T01:02:09.857Z",
+      "lastSyncedCommit": ""
+    },
+    "C0B21HSF4VA": {
+      "name": "event-ai-forum-ai-hackathon-2026",
+      "type": "event",
+      "mapping": {
+        "kind": "event",
+        "events": [
+          {
+            "slug": "aotearoa-ai-hackathon-festival-2026",
+            "eventId": 96
+          }
+        ]
+      },
+      "watermarkTs": "1780925237.266819",
+      "threads": {
+        "1778118947.075649": {
+          "replyCount": 1,
+          "latestReplyTs": "1778120794.177099"
+        },
+        "1780115194.015579": {
+          "replyCount": 1,
+          "latestReplyTs": "1780299916.233239"
+        },
+        "1780860021.130839": {
+          "replyCount": 2,
+          "latestReplyTs": "1780906830.750719"
+        },
+        "1780860072.032599": {
+          "replyCount": 1,
+          "latestReplyTs": "1780860084.327209"
+        },
+        "1780865474.757109": {
+          "replyCount": 2,
+          "latestReplyTs": "1780866088.415609"
+        },
+        "1780919778.564669": {
+          "replyCount": 2,
+          "latestReplyTs": "1780963107.398419"
+        }
+      },
+      "fingerprint": "sha256:41a3a725789f1ea954766266888475d342753de31dc86990a9562add068fa6a4",
+      "lastSyncedAt": "2026-06-09T01:01:37.429Z",
+      "lastSyncedCommit": ""
+    },
+    "C0B7K8BFN30": {
+      "name": "event-myob-ai-in-practice-30july-2026",
+      "type": "event",
+      "mapping": {
+        "kind": "event",
+        "events": [
+          {
+            "slug": "she-sharp-and-myob-working-smarter",
+            "eventId": 95
+          }
+        ]
+      },
+      "watermarkTs": "1780954764.500039",
+      "threads": {
+        "1780375315.572929": {
+          "replyCount": 4,
+          "latestReplyTs": "1780376474.352719"
+        },
+        "1780665906.651489": {
+          "replyCount": 2,
+          "latestReplyTs": "1780905192.767009"
+        },
+        "1780713598.572869": {
+          "replyCount": 1,
+          "latestReplyTs": "1780734241.577189"
+        },
+        "1780905968.835889": {
+          "replyCount": 12,
+          "latestReplyTs": "1780939295.440359"
+        }
+      },
+      "fingerprint": "sha256:e331d1ead7680a8f0afd1d2dc417d960d0ae565be5fc9110c2a349f018ed8b16",
+      "lastSyncedAt": "2026-06-09T01:04:02.586Z",
+      "lastSyncedCommit": ""
+    },
+    "C0L3U3Z7H": {
+      "name": "goodies",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555697.838329",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "C10JB9PJ6": {
+      "name": "team-contacts",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555698.818079",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "CAX7EK06Q": {
+      "name": "expense-receipts",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555699.781849",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "CGJPELDC4": {
+      "name": "marketing",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1780556832.233329",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "CSHSGQWF6": {
+      "name": "industry",
+      "type": "general",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1780114226.689319",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    },
+    "CSL6BBLQP": {
+      "name": "events-ey-2020",
+      "type": "event",
+      "mapping": {
+        "kind": "none"
+      },
+      "watermarkTs": "1777555702.716959",
+      "threads": {},
+      "fingerprint": "",
+      "lastSyncedAt": "2026-06-09T01:06:45.086Z",
+      "lastSyncedCommit": ""
+    }
+  }
+}


### PR DESCRIPTION
## Why

The `sync-event-from-slack` skill synced **one user-named channel** and re-read its **entire history** on every run, with **no memory** of what it had already read. Event **slugs also differ from channel names** (e.g. `event-myob-ai-in-practice-30july-2026` → `she-sharp-and-myob-working-smarter`), so the channel↔event linkage was lost between runs and had to be re-derived by hand.

## What

Three blocks, plus a committed memory:

**1. Discovery — `discover-channels.ts` (new)**
Workspace-wide triage front door. Compact table (one row per channel, never message bodies) → Claude learns the whole workspace in one read. Classifies event vs general, cross-references the manifest, surfaces only what changed. Auto-scans **general channels** for event signals (Humanitix/Eventbrite/lu.ma, dates, RSVP, posters) **in-script** so chatter never reaches context. `--join` self-joins public channels (`channels:join`); `--propose` gives fuzzy backfill suggestions.

**2. Incremental reads — `fetch-channel.ts` (modified)**
`--since`/`--state` returns only the delta. Catches **fresh replies on old threads** via per-thread `replyCount`/`latestReplyTs` (those don't move the top-level watermark — a naive `oldest` filter misses them). Adds a `_meta` trailer + gitignored session cache. Full fetch remains the default (back-compatible).

**3. Durable state — `update-state.ts` + `state-lib.ts` (new), `state/sync-state.json` (committed)**
Atomic, deterministically-ordered manifest writer with a content **fingerprint** (over `events-custom.json`) for **no-op short-circuiting**. Supports **multi-event channels** (one channel → several events, e.g. the peyvand "13 & 20 June" channel). The manifest links each channel to its event(s) and is the memory that makes future syncs cheap.

## Token economics

- Discovery = one small table, not full channels.
- `--since`/`--state` → only **new** messages enter context after first sync.
- Fingerprint no-op → unchanged channels cost **≈0 Claude tokens** (verified: re-sync of a synced channel returns `newCount: 0`, 0 message bodies).

## Backfill

Seeded the manifest for **10 of the 12 live events** across 9 channels + the **2 known skips** (`event-msd-series-2026` umbrella, `event-security-xero-october-2026` insufficient data), and baselined all other member channels. Two events (`from-burnout-to-balance`, `she-sharp-candice-murray-own-your-energy`) were left unmapped pending channel confirmation.

## Test plan

- [x] `discover-channels.ts` live run → steady state reads **`0 need attention, 177 quiet`**.
- [x] `fetch-channel.ts --state` on a synced channel → `mode: incremental`, `newCount: 0`, 0 bodies, pinned still included.
- [x] `update-state.ts` re-record → **no churn** ("no change", manifest byte-stable).
- [x] Multi-event mapping verified (peyvand channel → events 93 & 94).
- [x] CI gate `verify-image-paths.ts` → green (175 paths).
- [x] `state/` git-tracked, `.cache/` ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)