### PR TITLE
fix(events): use Humanitix registration URL for her-waka (March)

### DIFF
--- a/.claude/skills/sync-event-from-slack/state/sync-state.json
+++ b/.claude/skills/sync-event-from-slack/state/sync-state.json
@@ -1382,8 +1382,8 @@
           "latestReplyTs": "1774493877.064439"
         }
       },
-      "fingerprint": "sha256:cfacdffd15546fe05252d02aa5ef78bd53120e392585ade87ecfb110d18a10c9",
-      "lastSyncedAt": "2026-06-09T01:02:38.619Z",
+      "fingerprint": "sha256:e0a7553aa6ad8cef9f5d5996d8b587f2eb070968ea472c15f5f2421d7db5b85d",
+      "lastSyncedAt": "2026-06-09T02:02:24.506Z",
       "lastSyncedCommit": ""
     },
     "C0AFX3C4H5Z": {

--- a/lib/data/json/events-custom.json
+++ b/lib/data/json/events-custom.json
@@ -831,7 +831,7 @@
         ],
         "photos": [],
         "galleryUrl": "https://photos.app.goo.gl/FKFwVTSD7RxK7Sws6",
-        "registrationUrl": "https://shesharp.org.nz/events/her-waka",
+        "registrationUrl": "https://events.humanitix.com/she-sharp-ministry-of-social-development-academyex-her-waka",
         "images": [],
         "category": "workshop",
         "status": "completed",


### PR DESCRIPTION
## What

The March her-waka event (id 88) had its `registrationUrl` set to the internal detail page (`shesharp.org.nz/events/her-waka`), while the other three her-waka events (April/May/June) use their Humanitix links. This aligns March with the series using the canonical Humanitix URL confirmed in the planning channel `event-msd-march-2026`:

`https://events.humanitix.com/she-sharp-ministry-of-social-development-academyex-her-waka`

`detailPageUrl` and `detailPageData.url` are unchanged (they correctly point to the internal detail page). Also re-baselines the sync-state manifest fingerprint for that channel.

Found during a forced deep re-verification of all 12 live events against their Slack channels — this was the only drift; everything else was in sync.

## Test plan

- [x] `verify-image-paths.ts` → green (175 paths)
- [x] events-custom.json valid JSON; only event 88 `registrationUrl` changed
- [x] manifest fingerprint re-baselined (no `fingerprint-stale` next run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)